### PR TITLE
Update masternodemanager.ui

### DIFF
--- a/src/qt/forms/masternodemanager.ui
+++ b/src/qt/forms/masternodemanager.ui
@@ -46,9 +46,6 @@
            <property name="editTriggers">
             <set>QAbstractItemView::NoEditTriggers</set>
            </property>
-           <property name="alternatingRowColors">
-            <bool>true</bool>
-           </property>
            <property name="selectionBehavior">
             <enum>QAbstractItemView::SelectRows</enum>
            </property>


### PR DESCRIPTION
Removed 
<property name="alternatingRowColors">
            <bool>true</bool>
           </property>

Causes masternode text to be illegible in dark colour scheme; alternately we could create a text color property to offset white on white