### PR TITLE
Masternode score calculation changes

### DIFF
--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -595,6 +595,7 @@ uint256 CMasterNode::CalculateScore(int mod, int64_t nBlockHeight)
     uint256 blockControlHash = Hash(BEGIN(blockHash), END(blockHash));
     uint256 mnCollateralHash = Hash(BEGIN(mnCollateral), END(mnCollateral));
 
+    uint256 score;
     if (mnCollateralHash > blockControlHash)
     {
         score = mnCollateralHash - blockControlHash;

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -587,17 +587,24 @@ uint256 CMasterNode::CalculateScore(int mod, int64_t nBlockHeight)
 {
     if(pindexBest == NULL) return 0;
 
-    uint256 hash = 0;
-    uint256 aux = vin.prevout.hash + vin.prevout.n;
+    uint256 blockHash = 0;
+    uint256 mnCollateral = vin.prevout.hash + vin.prevout.n;
 
-    if(!GetBlockHash(hash, nBlockHeight)) return 0;
+    if(!GetBlockHash(blockHash, nBlockHeight)) return 0;
 
-    uint256 hash2 = Hash(BEGIN(hash), END(hash));
-    uint256 hash3 = Hash(BEGIN(aux), END(aux));
+    uint256 blockControlHash = Hash(BEGIN(blockHash), END(blockHash));
+    uint256 mnCollateralHash = Hash(BEGIN(mnCollateral), END(mnCollateral));
 
-    uint256 r = (hash3 > hash2 ? hash3 - hash2 : hash2 - hash3);
+    if (mnCollateralHash > blockControlHash)
+    {
+        score = mnCollateralHash - blockControlHash;
+    }
+    else
+    {
+        score = blockControlHash - mnCollateralHash;
+    }
 
-    return r;
+    return score;
 }
 
 void CMasterNode::Check()

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -593,7 +593,7 @@ uint256 CMasterNode::CalculateScore(int mod, int64_t nBlockHeight)
     if(!GetBlockHash(hash, nBlockHeight)) return 0;
 
     uint256 hash2 = Hash(BEGIN(hash), END(hash));
-    uint256 hash3 = Hash(BEGIN(hash), END(aux));
+    uint256 hash3 = Hash(BEGIN(aux), END(aux));
 
     uint256 r = (hash3 > hash2 ? hash3 - hash2 : hash2 - hash3);
 

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -593,7 +593,9 @@ uint256 CMasterNode::CalculateScore(int mod, int64_t nBlockHeight)
     if(!GetBlockHash(blockHash, nBlockHeight)) return 0;
 
     uint256 blockControlHash = Hash(BEGIN(blockHash), END(blockHash));
-    uint256 mnCollateralHash = Hash(BEGIN(mnCollateral), END(mnCollateral));
+    uint256 mnCollateralHash = Hash(
+        BEGIN(blockHash), END(blockHash),
+        BEGIN(mnCollateral), END(mnCollateral));
 
     uint256 score;
     if (mnCollateralHash > blockControlHash)


### PR DESCRIPTION
There's currently an issue/typo in the masternode score calculation.
My first commit resolves this typo.
The other changes are meant to improve the score calculation so that the masternode collateral hash that is compared against changes with every block.  This way a masternode doesn't get stuck with a hash that is high, low, or average.  This should result in a better distribution of winning nodes.