### PR TITLE
Reduce CircleCI builds to once a week.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,7 @@ workflows:
   nightly:
     triggers:
       - schedule:
-          cron: "00 12 * * *"
+          cron: "00 12 * * 0"
           filters:
             branches:
               only:


### PR DESCRIPTION
Every 24 hours for each branch is too excessive and consumed a lot of build mins per month. The CircleCI free limit is 1500.