### PR TITLE
masternodemanager

### DIFF
--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -438,6 +438,23 @@ int GetInputDarksendRounds(CTxIn in, int rounds)
     return rounds-1;
 }
 
+// manage the masternode connections
+void CDarkSendPool::ProcessMasternodeConnections()
+{
+    LOCK(cs_vNodes);
+	
+    BOOST_FOREACH(CNode* pnode, vNodes)
+    {
+        //if it's our masternode, let it be
+        if(submittedToMasternode == pnode->addr) continue;
+	    
+         if(pnode->fDarkSendMaster){
+            LogPrintf("Closing masternode connection %s \n", pnode->addr.ToString().c_str());
+            pnode->CloseSocketDisconnect();
+        }
+    }
+}
+
 void CDarkSendPool::Reset(){
     cachedLastSuccess = 0;
     vecMasternodesUsed.clear();
@@ -1312,7 +1329,6 @@ void CDarkSendPool::NewBlock()
     if(!fMasterNode){
         //denominate all non-denominated inputs every 25 minutes.
         if(pindexBest->nHeight % 10 == 0) UnlockCoins();
-        ProcessMasternodeConnections();
     }
 }
 
@@ -2120,34 +2136,27 @@ void ThreadCheckDarkSendPool()
         darkSendPool.CheckTimeout();
 
         if(c % 60 == 0){
-            LOCK(cs_main);
-            /*
-                cs_main is required for doing masternode.Check because something
-                is modifying the coins view without a mempool lock. It causes
-                segfaults from this code without the cs_main lock.
-            */
-
-            vector<CMasterNode>::iterator it = vecMasternodes.begin();
-            //check them separately
-            while(it != vecMasternodes.end()){
-                (*it).Check();
-                ++it;
-            }
-
-            //remove inactive
-            it = vecMasternodes.begin();
-            while(it != vecMasternodes.end()){
-                if((*it).enabled == 4 || (*it).enabled == 3){
-                    LogPrintf("Removing inactive masternode %s\n", (*it).addr.ToString().c_str());
-                    it = vecMasternodes.erase(it);
-                } else {
-                    ++it;
-                }
-            }
-
+	    darkSendPool.ProcessMasternodeConnections();
             masternodePayments.CleanPaymentList();
             CleanTransactionLocksList();
         }
+	    
+         // nodes refuse to relay dseep if it was less then MASTERNODE_MIN_DSEEP_SECONDS ago
+        // MASTERNODE_PING_WAIT_SECONDS gives some additional time on top of it
+        if(c % (MASTERNODE_MIN_DSEEP_SECONDS + MASTERNODE_PING_WAIT_SECONDS) == 0)
+        {
+            LOCK(cs_main);
+            /*
+                cs_main is required for doing CMasternode.Check because something
+                is modifying the coins view without a mempool lock. It causes
+                segfaults from this code without the cs_main lock.
+            */
+            mnodeman.CheckAndRemove();
+        }
+           
+	    if(c % MASTERNODE_PING_SECONDS == 0) activeMasternode.ManageStatus();
+	    
+	    if(c % MASTERNODES_DUMP_SECONDS == 0) DumpMasternodes();
 
         //try to sync the masternode list and payment list every 5 seconds from at least 3 nodes
         if(c % 5 == 0 && RequestedMasterNodeList < 3){
@@ -2173,10 +2182,6 @@ void ThreadCheckDarkSendPool()
                     }
                 }
             }
-        }
-
-        if(c % MASTERNODE_PING_SECONDS == 0){
-            activeMasternode.ManageStatus();
         }
 
         if(c % 60 == 0){

--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -2139,21 +2139,22 @@ void ThreadCheckDarkSendPool()
 	    darkSendPool.ProcessMasternodeConnections();
             masternodePayments.CleanPaymentList();
             CleanTransactionLocksList();
+    
+            //nodes refuse to relay dseep if it was less then MASTERNODE_MIN_DSEEP_SECONDS ago
+            // MASTERNODE_PING_WAIT_SECONDS gives some additional time on top of it
+            // so we have a timeout for this check on start unless we need to
+            if(c > MASTERNODE_MIN_DSEEP_SECONDS + MASTERNODE_PING_WAIT_SECONDS || mnodeman.UpdateNeeded())
+            {
+                LOCK(cs_main);
+                /*
+                    cs_main is required for doing CMasternode.Check because something
+                    is modifying the coins view without a mempool lock. It causes
+                    segfaults from this code without the cs_main lock.
+                */
+                mnodeman.CheckAndRemove();
+            }
         }
-	    
-         // nodes refuse to relay dseep if it was less then MASTERNODE_MIN_DSEEP_SECONDS ago
-        // MASTERNODE_PING_WAIT_SECONDS gives some additional time on top of it
-        if(c % (MASTERNODE_MIN_DSEEP_SECONDS + MASTERNODE_PING_WAIT_SECONDS) == 0)
-        {
-            LOCK(cs_main);
-            /*
-                cs_main is required for doing CMasternode.Check because something
-                is modifying the coins view without a mempool lock. It causes
-                segfaults from this code without the cs_main lock.
-            */
-            mnodeman.CheckAndRemove();
-        }
-           
+       
 	    if(c % MASTERNODE_PING_SECONDS == 0) activeMasternode.ManageStatus();
 	    
 	    if(c % MASTERNODES_DUMP_SECONDS == 0) DumpMasternodes();
@@ -2173,8 +2174,8 @@ void ThreadCheckDarkSendPool()
 
                         LogPrintf("Successfully synced, asking for Masternode list and payment list\n");
 
-                        //request full mn list only if we didn't load them from masternodes.dat yet
-                        if(mnodeman.size() == 0) pnode->PushMessage("dseg", CTxIn());
+                        //request full mn list only if masternodes.dat was updated quite a long time ago
+                        if(mnodeman.UpdateNeeded()) pnode->PushMessage("dseg", CTxIn());
 			    
                         pnode->PushMessage("mnget"); //sync payees
                         pnode->PushMessage("getsporks"); //get current network sporks

--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -2135,24 +2135,18 @@ void ThreadCheckDarkSendPool()
         //LogPrintf("ThreadCheckDarkSendPool::check timeout\n");
         darkSendPool.CheckTimeout();
 
-        if(c % 60 == 0){
+        if(c % 60 == 0)
+        {
+            LOCK(cs_main);
+            /*
+                cs_main is required for doing CMasternode.Check because something
+                is modifying the coins view without a mempool lock. It causes
+                segfaults from this code without the cs_main lock.
+            */
+            mnodeman.CheckAndRemove();
 	    darkSendPool.ProcessMasternodeConnections();
             masternodePayments.CleanPaymentList();
             CleanTransactionLocksList();
-    
-            //nodes refuse to relay dseep if it was less then MASTERNODE_MIN_DSEEP_SECONDS ago
-            // MASTERNODE_PING_WAIT_SECONDS gives some additional time on top of it
-            // so we have a timeout for this check on start unless we need to
-            if(c > MASTERNODE_MIN_DSEEP_SECONDS + MASTERNODE_PING_WAIT_SECONDS || mnodeman.UpdateNeeded())
-            {
-                LOCK(cs_main);
-                /*
-                    cs_main is required for doing CMasternode.Check because something
-                    is modifying the coins view without a mempool lock. It causes
-                    segfaults from this code without the cs_main lock.
-                */
-                mnodeman.CheckAndRemove();
-            }
         }
        
 	    if(c % MASTERNODE_PING_SECONDS == 0) activeMasternode.ManageStatus();
@@ -2175,7 +2169,7 @@ void ThreadCheckDarkSendPool()
                         LogPrintf("Successfully synced, asking for Masternode list and payment list\n");
 
                         //request full mn list only if masternodes.dat was updated quite a long time ago
-                        if(mnodeman.UpdateNeeded()) pnode->PushMessage("dseg", CTxIn());
+                        mnodeman.DsegUpdate(pnode);
 			    
                         pnode->PushMessage("mnget"); //sync payees
                         pnode->PushMessage("getsporks"); //get current network sporks

--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -1575,7 +1575,7 @@ bool CDarkSendPool::DoAutomaticDenominating(bool fDryRun, bool ready)
             }
 
             lastTimeChanged = GetTimeMillis();
-                submittedToMasternode = vecMasternodes[i].addr;
+                submittedToMasternode = mn->addr;
             LogPrintf("DoAutomaticDenominating -- attempt %d connection to masternode %s\n", i, mn->addr.ToString().c_str());
             if(ConnectNode((CAddress)mn->addr, NULL, true)){
 

--- a/src/darksend.cpp
+++ b/src/darksend.cpp
@@ -8,7 +8,7 @@
 #include "init.h"
 //#include "script/sign.h"
 #include "util.h"
-#include "masternode.h"
+#include "masternodeman.h"
 #include "instantx.h"
 #include "ui_interface.h"
 //#include "random.h"
@@ -122,17 +122,18 @@ void ProcessMessageDarksend(CNode* pfrom, std::string& strCommand, CDataStream& 
         vRecv >> nDenom >> txCollateral;
 
         std::string error = "";
-        int mn = GetMasternodeByVin(activeMasternode.vin);
-        if(mn == -1){
+        CMasternode* mn = mnodeman.Find(activeMasternode.vin);
+        if(!mn)
+        {
             std::string strError = _("Not in the masternode list.");
             pfrom->PushMessage("dssu", darkSendPool.sessionID, darkSendPool.GetState(), darkSendPool.GetEntriesCount(), MASTERNODE_REJECTED, strError);
             return;
         }
 
         if(darkSendPool.sessionUsers == 0) {
-            if(vecMasternodes[mn].nLastDsq != 0 &&
-                vecMasternodes[mn].nLastDsq + CountMasternodesAboveProtocol(darkSendPool.MIN_PEER_PROTO_VERSION)/5 > darkSendPool.nDsqCount){
-                //LogPrintf("dsa -- last dsq too recent, must wait. %s \n", vecMasternodes[mn].addr.ToString().c_str());
+             if(mn->nLastDsq != 0 &&
+                mn->nLastDsq + mnodeman.CountMasternodesAboveProtocol(darkSendPool.MIN_PEER_PROTO_VERSION)/5 > darkSendPool.nDsqCount){
+                LogPrintf("dsa -- last dsq too recent, must wait. %s \n", mn->addr.ToString().c_str());
                 std::string strError = _("Last Darksend was too recent.");
                 pfrom->PushMessage("dssu", darkSendPool.sessionID, darkSendPool.GetState(), darkSendPool.GetEntriesCount(), MASTERNODE_REJECTED, strError);
                 return;
@@ -165,8 +166,8 @@ void ProcessMessageDarksend(CNode* pfrom, std::string& strCommand, CDataStream& 
 
         if(dsq.IsExpired()) return;
 
-        int mn = GetMasternodeByVin(dsq.vin);
-        if(mn == -1) return;
+        CMasternode* mn = mnodeman.Find(dsq.vin);
+        if(!mn) return;
 
         // if the queue is ready, submit if we can
         if(dsq.ready) {
@@ -182,16 +183,16 @@ void ProcessMessageDarksend(CNode* pfrom, std::string& strCommand, CDataStream& 
                 if(q.vin == dsq.vin) return;
             }
 
-            if(fDebug) LogPrintf("dsq last %d last2 %d count %d\n", vecMasternodes[mn].nLastDsq, vecMasternodes[mn].nLastDsq + (int)vecMasternodes.size()/5, darkSendPool.nDsqCount);
+             if(fDebug) LogPrintf("dsq last %d last2 %d count %d\n", mn->nLastDsq, mn->nLastDsq + mnodeman.size()/5, darkSendPool.nDsqCount);
             //don't allow a few nodes to dominate the queuing process
-            if(vecMasternodes[mn].nLastDsq != 0 &&
-                vecMasternodes[mn].nLastDsq + CountMasternodesAboveProtocol(darkSendPool.MIN_PEER_PROTO_VERSION)/5 > darkSendPool.nDsqCount){
-                if(fDebug) LogPrintf("dsq -- masternode sending too many dsq messages. %s \n", vecMasternodes[mn].addr.ToString().c_str());
+           if(mn->nLastDsq != 0 &&
+                mn->nLastDsq + mnodeman.CountMasternodesAboveProtocol(darkSendPool.MIN_PEER_PROTO_VERSION)/5 > darkSendPool.nDsqCount){
+                if(fDebug) LogPrintf("dsq -- masternode sending too many dsq messages. %s \n", mn->addr.ToString().c_str());
                 return;
             }
             darkSendPool.nDsqCount++;
-            vecMasternodes[mn].nLastDsq = darkSendPool.nDsqCount;
-            vecMasternodes[mn].allowFreeTx = true;
+            mn->nLastDsq = darkSendPool.nDsqCount;
+            mn->allowFreeTx = true;
 
             if(fDebug) LogPrintf("dsq - new darksend queue object - %s\n", addr.ToString().c_str());
             vecDarksendQueue.push_back(dsq);
@@ -1380,7 +1381,7 @@ bool CDarkSendPool::DoAutomaticDenominating(bool fDryRun, bool ready)
         }
     }
 
-    if(vecMasternodes.size() == 0){
+    if(mnodeman.size() == 0){
         if(fDebug) LogPrintf("CDarkSendPool::DoAutomaticDenominating - No masternodes detected\n");
         strAutoDenomResult = _("No masternodes detected.");
         return false;
@@ -1533,40 +1534,39 @@ bool CDarkSendPool::DoAutomaticDenominating(bool fDryRun, bool ready)
             }
         }
 
-        //shuffle masternodes around before we try to connect
-        std::random_shuffle ( vecMasternodes.begin(), vecMasternodes.end() );
         int i = 0;
 
         // otherwise, try one randomly
         while(i < 10)
         {
+	    CMasternode* mn = mnodeman.FindRandom();
             //don't reuse masternodes
             BOOST_FOREACH(CTxIn usedVin, vecMasternodesUsed) {
-                if(vecMasternodes[i].vin == usedVin){
+                 if(mn->vin == usedVin){
                     i++;
                     continue;
                 }
             }
-            if(vecMasternodes[i].protocolVersion < MIN_PEER_PROTO_VERSION) {
+            if(mn->protocolVersion < darkSendPool.MIN_PEER_PROTO_VERSION) {
                 i++;
                 continue;
             }
 
-            if(vecMasternodes[i].nLastDsq != 0 &&
-                vecMasternodes[i].nLastDsq + CountMasternodesAboveProtocol(darkSendPool.MIN_PEER_PROTO_VERSION)/5 > darkSendPool.nDsqCount){
+          if(mn->nLastDsq != 0 &&
+                mn->nLastDsq + mnodeman.CountMasternodesAboveProtocol(darkSendPool.MIN_PEER_PROTO_VERSION)/5 > darkSendPool.nDsqCount){
                 i++;
                 continue;
             }
 
             lastTimeChanged = GetTimeMillis();
-            LogPrintf("DoAutomaticDenominating -- attempt %d connection to masternode %s\n", i, vecMasternodes[i].addr.ToString().c_str());
-            if(ConnectNode((CAddress)vecMasternodes[i].addr, NULL, true)){
                 submittedToMasternode = vecMasternodes[i].addr;
+            LogPrintf("DoAutomaticDenominating -- attempt %d connection to masternode %s\n", i, mn->addr.ToString().c_str());
+            if(ConnectNode((CAddress)mn->addr, NULL, true)){
 
                 LOCK(cs_vNodes);
                 BOOST_FOREACH(CNode* pnode, vNodes)
                 {
-                    if((CNetAddr)pnode->addr != (CNetAddr)vecMasternodes[i].addr) continue;
+                    if((CNetAddr)pnode->addr != (CNetAddr)mn->addr) continue;
 
                     std::string strReason;
                     if(txCollateral == CTransaction()){
@@ -1576,7 +1576,7 @@ bool CDarkSendPool::DoAutomaticDenominating(bool fDryRun, bool ready)
                         }
                     }
 
-                    vecMasternodesUsed.push_back(vecMasternodes[i].vin);
+                    vecMasternodesUsed.push_back(mn->vin)
 
                     std::vector<int64_t> vecAmounts;
                     pwalletMain->ConvertList(vCoins, vecAmounts);
@@ -2084,18 +2084,16 @@ bool CDarksendQueue::Relay()
 
 bool CDarksendQueue::CheckSignature()
 {
-    BOOST_FOREACH(CMasterNode& mn, vecMasternodes) {
-
-        if(mn.vin == vin) {
-            std::string strMessage = vin.ToString() + boost::lexical_cast<std::string>(nDenom) + boost::lexical_cast<std::string>(time) + boost::lexical_cast<std::string>(ready);
-
-            std::string errorMessage = "";
-            if(!darkSendSigner.VerifyMessage(mn.pubkey2, vchSig, strMessage, errorMessage)){
-                return error("CDarksendQueue::CheckSignature() - Got bad masternode address signature %s \n", vin.ToString().c_str());
-            }
-
-            return true;
+     CMasternode* mn = mnodeman.Find(vin);
+     if(mn)
+    {
+        std::string strMessage = vin.ToString() + boost::lexical_cast<std::string>(nDenom) + boost::lexical_cast<std::string>(time) + boost::lexical_cast<std::string>(ready);
+        std::string errorMessage = "";
+        if(!darkSendSigner.VerifyMessage(mn->pubkey2, vchSig, strMessage, errorMessage)){
+            return error("CDarksendQueue::CheckSignature() - Got bad masternode address signature %s \n", vin.ToString().c_str());
         }
+	     
+	    return true;
     }
 
     return false;
@@ -2166,7 +2164,9 @@ void ThreadCheckDarkSendPool()
 
                         LogPrintf("Successfully synced, asking for Masternode list and payment list\n");
 
-                        pnode->PushMessage("dseg", CTxIn()); //request full mn list
+                        //request full mn list only if we didn't load them from masternodes.dat yet
+                        if(mnodeman.size() == 0) pnode->PushMessage("dseg", CTxIn());
+			    
                         pnode->PushMessage("mnget"); //sync payees
                         pnode->PushMessage("getsporks"); //get current network sporks
                         RequestedMasterNodeList++;
@@ -2181,7 +2181,7 @@ void ThreadCheckDarkSendPool()
 
         if(c % 60 == 0){
             //if we've used 1/5 of the masternode list, then clear the list.
-            if((int)vecMasternodesUsed.size() > (int)vecMasternodes.size() / 5)
+            if((int)vecMasternodesUsed.size() > (int)mnodeman.size() / 5)
                 vecMasternodesUsed.clear();
         }
 

--- a/src/darksend.h
+++ b/src/darksend.h
@@ -7,8 +7,8 @@
 
 //#include "primitives/transaction.h"
 #include "main.h"
-#include "masternode.h"
 #include "activemasternode.h"
+#include "masternodeman.h"
 
 class CTxIn;
 class CDarkSendPool;
@@ -160,22 +160,22 @@ public:
 
     bool GetAddress(CService &addr)
     {
-        BOOST_FOREACH(CMasterNode mn, vecMasternodes) {
-            if(mn.vin == vin){
-                addr = mn.addr;
-                return true;
-            }
+      CMasternode* mn = mnodeman.Find(vin);
+      if(mn)
+      {
+            addr = mn->addr;
+            return true;
         }
         return false;
     }
 
     bool GetProtocolVersion(int &protocolVersion)
     {
-        BOOST_FOREACH(CMasterNode mn, vecMasternodes) {
-            if(mn.vin == vin){
-                protocolVersion = mn.protocolVersion;
-                return true;
-            }
+        CMasternode* mn = mnodeman.Find(vin);
+        if(mn)
+        {
+            protocolVersion = mn->protocolVersion;
+            return true;
         }
         return false;
     }

--- a/src/darksend.h
+++ b/src/darksend.h
@@ -289,7 +289,9 @@ public:
 
         SetNull();
     }
-
+	
+    void ProcessMasternodeConnections();
+	
     void InitCollateralAddress(){
         std::string strAddress = "";
             strAddress = "8TSV23mk6whxTHjritUD1RotLxX6KG9yGN";

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -12,6 +12,7 @@
 #include "util.h"
 #include "ui_interface.h"
 #include "activemasternode.h"
+#include "masternodeman.h"
 #include "masternodeconfig.h"
 #include "spork.h"
 #include "keepass.h"
@@ -121,6 +122,7 @@ void Shutdown()
         bitdb.Flush(false);
 #endif
     StopNode();
+    DumpMasternodes();
     UnregisterNodeSignals(GetNodeSignals());
     {
         LOCK(cs_main);
@@ -1132,7 +1134,21 @@ bool AppInit2(boost::thread_group& threadGroup)
 
     if (!strErrors.str().empty())
         return InitError(strErrors.str());
-
+	
+uiInterface.InitMessage(_("Loading masternode list..."));
+	
+     nStart = GetTimeMillis();
+	
+     {
+        CMasternodeDB mndb;
+        if (!mndb.Read(mnodeman))
+            LogPrintf("Invalid or missing masternodes.dat; recreating\n");
+    }
+	
+     LogPrintf("Loaded %i masternodes from masternodes.dat  %dms\n",
+           mnodeman.size(), GetTimeMillis() - nStart);
+	
+	
     fMasterNode = GetBoolArg("-masternode", false);
     if(fMasterNode) {
         LogPrintf("IS DARKSEND MASTER NODE\n");

--- a/src/instantx.cpp
+++ b/src/instantx.cpp
@@ -9,8 +9,8 @@
 #include "base58.h"
 #include "protocol.h"
 #include "instantx.h"
-#include "masternode.h"
 #include "activemasternode.h"
+#include "masternodeman.h"
 #include "darksend.h"
 #include "spork.h"
 #include <boost/lexical_cast.hpp>
@@ -256,7 +256,7 @@ void DoConsensusVote(CTransaction& tx, int64_t nBlockHeight)
 {
     if(!fMasterNode) return;
 
-    int n = GetMasternodeRank(activeMasternode.vin, nBlockHeight, MIN_INSTANTX_PROTO_VERSION);
+    int n = mnodeman.GetMasternodeRank(activeMasternode.vin, nBlockHeight, MIN_INSTANTX_PROTO_VERSION);
 
     if(n == -1)
     {
@@ -304,11 +304,12 @@ void DoConsensusVote(CTransaction& tx, int64_t nBlockHeight)
 //received a consensus vote
 bool ProcessConsensusVote(CConsensusVote& ctx)
 {
-    int n = GetMasternodeRank(ctx.vinMasternode, ctx.nBlockHeight, MIN_INSTANTX_PROTO_VERSION);
+    int n = mnodeman.GetMasternodeRank(ctx.vinMasternode, ctx.nBlockHeight, MIN_INSTANTX_PROTO_VERSION);
 
-    int x = GetMasternodeByVin(ctx.vinMasternode);
-    if(x != -1){
-        if(fDebug) LogPrintf("InstantX::ProcessConsensusVote - Masternode ADDR %s %d\n", vecMasternodes[x].addr.ToString().c_str(), n);
+    CMasternode* mn = mnodeman.Find(ctx.vinMasternode);
+    if(mn)
+    {
+        if(fDebug) LogPrintf("InstantX::ProcessConsensusVote - Masternode ADDR %s %d\n", mn->addr.ToString().c_str(), n);
     }
 
     if(n == -1)
@@ -477,9 +478,9 @@ bool CConsensusVote::SignatureValid()
     std::string strMessage = txHash.ToString().c_str() + boost::lexical_cast<std::string>(nBlockHeight);
     //LogPrintf("verify strMessage %s \n", strMessage.c_str());
 
-    int n = GetMasternodeByVin(vinMasternode);
+    CMasternode* mn = mnodeman.Find(vinMasternode);
 
-    if(n == -1)
+    if(!mn)
     {
         LogPrintf("InstantX::CConsensusVote::SignatureValid() - Unknown Masternode\n");
         return false;
@@ -490,13 +491,13 @@ bool CConsensusVote::SignatureValid()
     //LogPrintf("verify addr %d %s \n", n, vecMasternodes[n].addr.ToString().c_str());
 
     CScript pubkey;
-    pubkey =GetScriptForDestination(vecMasternodes[n].pubkey2.GetID());
+    pubkey.SetDestination(mn->pubkey2.GetID());
     CTxDestination address1;
     ExtractDestination(pubkey, address1);
     CBitcoinAddress address2(address1);
     //LogPrintf("verify pubkey2 %s \n", address2.ToString().c_str());
 
-    if(!darkSendSigner.VerifyMessage(vecMasternodes[n].pubkey2, vchMasterNodeSignature, strMessage, errorMessage)) {
+    if(!darkSendSigner.VerifyMessage(mn->pubkey2, vchMasterNodeSignature, strMessage, errorMessage)) {
         LogPrintf("InstantX::CConsensusVote::SignatureValid() - Verify message failed\n");
         return false;
     }
@@ -546,7 +547,7 @@ bool CTransactionLock::SignaturesValid()
 
     BOOST_FOREACH(CConsensusVote vote, vecConsensusVotes)
     {
-        int n = GetMasternodeRank(vote.vinMasternode, vote.nBlockHeight, MIN_INSTANTX_PROTO_VERSION);
+        int n = mnodeman.GetMasternodeRank(vote.vinMasternode, vote.nBlockHeight, MIN_INSTANTX_PROTO_VERSION);
 
         if(n == -1)
         {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4572,7 +4572,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
     else
     {
         ProcessMessageDarksend(pfrom, strCommand, vRecv);
-        ProcessMessageMasternode(pfrom, strCommand, vRecv);
+        mnodeman.ProcessMessage(pfrom, strCommand, vRecv);
         ProcessMessageInstantX(pfrom, strCommand, vRecv);
         ProcessSpork(pfrom, strCommand, vRecv);
 

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -1,5 +1,5 @@
 #include "masternode.h"
-#include "activemasternode.h"
+#include "masternodeman.h"
 #include "darksend.h"
 //#include "primitives/transaction.h"
 #include "main.h"
@@ -11,18 +11,12 @@
 int CMasterNode::minProtoVersion = MIN_MN_PROTO_VERSION;
 
 
-/** The list of active masternodes */
-std::vector<CMasterNode> vecMasternodes;
 /** Object for who's going to get paid on which blocks */
 CMasternodePayments masternodePayments;
 // keep track of masternode votes I've seen
 map<uint256, CMasternodePaymentWinner> mapSeenMasternodeVotes;
 // keep track of the scanning errors I've seen
 map<uint256, int> mapSeenMasternodeScanningErrors;
-// who's asked for the masternode list and the last time
-std::map<CNetAddr, int64_t> askedForMasternodeList;
-// which masternodes we've asked for
-std::map<COutPoint, int64_t> askedForMasternodeListEntry;
 // cache block hashes as we calculate them
 std::map<int64_t, uint256> mapCacheBlockHashes;
 
@@ -44,292 +38,7 @@ void ProcessMasternodeConnections(){
 
 void ProcessMessageMasternode(CNode* pfrom, std::string& strCommand, CDataStream& vRecv)
 {
-
-    if (strCommand == "dsee") { //DarkSend Election Entry
-        if(fLiteMode) return; //disable all darksend/masternode related functionality
-
-        bool fIsInitialDownload = IsInitialBlockDownload();
-        if(fIsInitialDownload) return;
-
-        CTxIn vin;
-        CService addr;
-        CPubKey pubkey;
-        CPubKey pubkey2;
-        vector<unsigned char> vchSig;
-        int64_t sigTime;
-        int count;
-        int current;
-        int64_t lastUpdated;
-        int protocolVersion;
-        std::string strMessage;
-
-        // 70047 and greater
-        vRecv >> vin >> addr >> vchSig >> sigTime >> pubkey >> pubkey2 >> count >> current >> lastUpdated >> protocolVersion;
-
-        // make sure signature isn't in the future (past is OK)
-        if (sigTime > GetAdjustedTime() + 60 * 60) {
-            LogPrintf("dsee - Signature rejected, too far into the future %s\n", vin.ToString().c_str());
-            return;
-        }
-
-        bool isLocal = addr.IsRFC1918() || addr.IsLocal();
-        //if(Params().MineBlocksOnDemand()) isLocal = false;
-
-        std::string vchPubKey(pubkey.begin(), pubkey.end());
-        std::string vchPubKey2(pubkey2.begin(), pubkey2.end());
-
-        strMessage = addr.ToString() + boost::lexical_cast<std::string>(sigTime) + vchPubKey + vchPubKey2 + boost::lexical_cast<std::string>(protocolVersion);
-
-        if(protocolVersion < MIN_MN_PROTO_VERSION) {
-            LogPrintf("dsee - ignoring outdated masternode %s protocol version %d\n", vin.ToString().c_str(), protocolVersion);
-            return;
-        }
-
-        CScript pubkeyScript;
-        pubkeyScript =GetScriptForDestination(pubkey.GetID());
-
-        if(pubkeyScript.size() != 25) {
-            LogPrintf("dsee - pubkey the wrong size\n");
-            pfrom->Misbehaving(100);
-            return;
-        }
-
-        CScript pubkeyScript2;
-        pubkeyScript2 =GetScriptForDestination(pubkey2.GetID());
-
-        if(pubkeyScript2.size() != 25) {
-            LogPrintf("dsee - pubkey2 the wrong size\n");
-            pfrom->Misbehaving(100);
-            return;
-        }
-
-        std::string errorMessage = "";
-        if(!darkSendSigner.VerifyMessage(pubkey, vchSig, strMessage, errorMessage)){
-            LogPrintf("dsee - Got bad masternode address signature\n");
-            pfrom->Misbehaving(100);
-            return;
-        }
-
-        
-
-        //search existing masternode list, this is where we update existing masternodes with new dsee broadcasts
-        BOOST_FOREACH(CMasterNode& mn, vecMasternodes) {
-            if(mn.vin.prevout == vin.prevout) {
-                // count == -1 when it's a new entry
-                //   e.g. We don't want the entry relayed/time updated when we're syncing the list
-                // mn.pubkey = pubkey, IsVinAssociatedWithPubkey is validated once below,
-                //   after that they just need to match
-                if(count == -1 && mn.pubkey == pubkey && !mn.UpdatedWithin(MASTERNODE_MIN_DSEE_SECONDS)){
-                    mn.UpdateLastSeen();
-
-                    if(mn.now < sigTime){ //take the newest entry
-                        LogPrintf("dsee - Got updated entry for %s\n", addr.ToString().c_str());
-                        mn.pubkey2 = pubkey2;
-                        mn.now = sigTime;
-                        mn.sig = vchSig;
-                        mn.protocolVersion = protocolVersion;
-                        mn.addr = addr;
-
-                        RelayDarkSendElectionEntry(vin, addr, vchSig, sigTime, pubkey, pubkey2, count, current, lastUpdated, protocolVersion);
-                    }
-                }
-
-                return;
-            } else if ((CNetAddr)mn.addr == (CNetAddr)addr) {
-                // don't add masternodes with the same service address as they
-                // are attempting to earn payments without contributing
-                // we won't mark the sending node as misbehaving unless
-                // they are the culprit 
-                LogPrintf("dsee - Already have mn with same service address:%s\n", addr.ToString());
-                if ((CNetAddr)pfrom->addr == (CNetAddr)addr)
-                    pfrom->Misbehaving(20);
-                return;
-            }
-        }
-
-        // make sure the vout that was signed is related to the transaction that spawned the masternode
-        //  - this is expensive, so it's only done once per masternode
-        if(!darkSendSigner.IsVinAssociatedWithPubkey(vin, pubkey)) {
-            LogPrintf("dsee - Got mismatched pubkey and vin\n");
-            pfrom->Misbehaving(100);
-            return;
-        }
-
-        if(fDebug) LogPrintf("dsee - Got NEW masternode entry %s\n", addr.ToString().c_str());
-
-        // make sure it's still unspent
-        //  - this is checked later by .check() in many places and by ThreadCheckDarkSendPool()
-
-        CValidationState state;
-        CTransaction tx = CTransaction();
-        int64_t nTempTxOut = (MASTERNODE_COLLATERAL / COIN) - 1;
-
-        CTxOut vout = CTxOut(nTempTxOut*COIN, darkSendPool.collateralPubKey);
-        tx.vin.push_back(vin);
-        tx.vout.push_back(vout);
-        bool pfMissingInputs = false;
-        if(AcceptableInputs(mempool, state, tx, false, &pfMissingInputs)){
-            if(fDebug) LogPrintf("dsee - Accepted masternode entry %i %i\n", count, current);
-
-            if(GetInputAge(vin) < MASTERNODE_MIN_CONFIRMATIONS){
-                LogPrintf("dsee - Input must have least %d confirmations\n", MASTERNODE_MIN_CONFIRMATIONS);
-                pfrom->Misbehaving(20);
-                return;
-            }
-
-            // use this as a peer
-            addrman.Add(CAddress(addr), pfrom->addr, 2*60*60);
-
-            // add our masternode
-            CMasterNode mn(addr, vin, pubkey, vchSig, sigTime, pubkey2, protocolVersion);
-            mn.UpdateLastSeen(lastUpdated);
-            vecMasternodes.push_back(mn);
-
-            // if it matches our masternodeprivkey, then we've been remotely activated
-            if(pubkey2 == activeMasternode.pubKeyMasternode && protocolVersion == PROTOCOL_VERSION){
-                activeMasternode.EnableHotColdMasterNode(vin, addr);
-            }
-
-            if(count == -1 && !isLocal)
-                RelayDarkSendElectionEntry(vin, addr, vchSig, sigTime, pubkey, pubkey2, count, current, lastUpdated, protocolVersion);
-
-        } else {
-            LogPrintf("dsee - Rejected masternode entry %s\n", addr.ToString().c_str());
-
-            int nDoS = 0;
-            if (state.IsInvalid(nDoS))
-            {
-                LogPrintf("dsee - %s from %s %s was not accepted into the memory pool\n", tx.GetHash().ToString().c_str(),
-                    pfrom->addr.ToString().c_str(), pfrom->cleanSubVer.c_str());
-                if (nDoS > 0)
-                    pfrom->Misbehaving(nDoS);
-            }
-        }
-    }
-
-    else if (strCommand == "dseep") { //DarkSend Election Entry Ping
-        if(fLiteMode) return; //disable all darksend/masternode related functionality
-        bool fIsInitialDownload = IsInitialBlockDownload();
-        if(fIsInitialDownload) return;
-
-        CTxIn vin;
-        vector<unsigned char> vchSig;
-        int64_t sigTime;
-        bool stop;
-        vRecv >> vin >> vchSig >> sigTime >> stop;
-
-        LogPrintf("dseep - Received: vin: %s sigTime: %lld stop: %s\n", vin.ToString().c_str(), sigTime, stop ? "true" : "false");
-
-        if (sigTime > GetAdjustedTime() + 60 * 60) {
-            LogPrintf("dseep - Signature rejected, too far into the future %s\n", vin.ToString().c_str());
-            return;
-        }
-
-        if (sigTime <= GetAdjustedTime() - 60 * 60) {
-            LogPrintf("dseep - Signature rejected, too far into the past %s - %d %d \n", vin.ToString().c_str(), sigTime, GetAdjustedTime());
-            return;
-        }
-
-        // see if we have this masternode
-
-        BOOST_FOREACH(CMasterNode& mn, vecMasternodes) {
-            if(mn.vin.prevout == vin.prevout) {
-            	// LogPrintf("dseep - Found corresponding mn for vin: %s\n", vin.ToString().c_str());
-            	// take this only if it's newer
-                if(mn.lastDseep < sigTime){
-                    std::string strMessage = mn.addr.ToString() + boost::lexical_cast<std::string>(sigTime) + boost::lexical_cast<std::string>(stop);
-
-                    std::string errorMessage = "";
-                    if(!darkSendSigner.VerifyMessage(mn.pubkey2, vchSig, strMessage, errorMessage)){
-                        LogPrintf("dseep - Got bad masternode address signature %s \n", vin.ToString().c_str());
-                        //pfrom->Misbehaving(100);
-                        return;
-                    }
-
-                    mn.lastDseep = sigTime;
-
-                    if(!mn.UpdatedWithin(MASTERNODE_MIN_DSEEP_SECONDS)){
-                        mn.UpdateLastSeen();
-                        if(stop) {
-                            mn.Disable();
-                            mn.Check();
-                        }
-                        RelayDarkSendElectionEntryPing(vin, vchSig, sigTime, stop);
-                    }
-                }
-                return;
-            }
-        }
-
-        LogPrintf("dseep - Couldn't find masternode entry %s\n", vin.ToString().c_str());
-
-        std::map<COutPoint, int64_t>::iterator i = askedForMasternodeListEntry.find(vin.prevout);
-        if (i != askedForMasternodeListEntry.end()){
-            int64_t t = (*i).second;
-            if (GetTime() < t) {
-                // we've asked recently
-                return;
-            }
-        }
-
-        // ask for the dsee info once from the node that sent dseep
-
-        LogPrintf("dseep - Asking source node for missing entry %s\n", vin.ToString().c_str());
-        pfrom->PushMessage("dseg", vin);
-        int64_t askAgain = GetTime()+(60*60*24);
-        askedForMasternodeListEntry[vin.prevout] = askAgain;
-
-    } else if (strCommand == "dseg") { //Get masternode list or specific entry
-        if(fLiteMode) return; //disable all darksend/masternode related functionality
-        CTxIn vin;
-        vRecv >> vin;
-
-        if(vin == CTxIn()) { //only should ask for this once
-            //local network
-            //Note tor peers show up as local proxied addrs //if(!pfrom->addr.IsRFC1918())//&& !Params().MineBlocksOnDemand())
-            //{
-                std::map<CNetAddr, int64_t>::iterator i = askedForMasternodeList.find(pfrom->addr);
-                if (i != askedForMasternodeList.end())
-                {
-                    int64_t t = (*i).second;
-                    if (GetTime() < t) {
-                        //pfrom->Misbehaving(34);
-                        //LogPrintf("dseg - peer already asked me for the list\n");
-                        //return;
-                    }
-                }
-
-                int64_t askAgain = GetTime()+(60*60*3);
-                askedForMasternodeList[pfrom->addr] = askAgain;
-            //}
-        } //else, asking for a specific node which is ok
-
-        int count = vecMasternodes.size();
-        int i = 0;
-
-        BOOST_FOREACH(CMasterNode mn, vecMasternodes) {
-
-            if(mn.addr.IsRFC1918()) continue; //local network
-
-            if(vin == CTxIn()){
-                mn.Check();
-                if(mn.IsEnabled()) {
-                    if(fDebug) LogPrintf("dseg - Sending masternode entry - %s \n", mn.addr.ToString().c_str());
-                    pfrom->PushMessage("dsee", mn.vin, mn.addr, mn.sig, mn.now, mn.pubkey, mn.pubkey2, count, i, mn.lastTimeSeen, mn.protocolVersion);
-                }
-            } else if (vin == mn.vin) {
-                if(fDebug) LogPrintf("dseg - Sending masternode entry - %s \n", mn.addr.ToString().c_str());
-                pfrom->PushMessage("dsee", mn.vin, mn.addr, mn.sig, mn.now, mn.pubkey, mn.pubkey2, count, i, mn.lastTimeSeen, mn.protocolVersion);
-                LogPrintf("dseg - Sent 1 masternode entries to %s\n", pfrom->addr.ToString().c_str());
-                return;
-            }
-            i++;
-        }
-
-        LogPrintf("dseg - Sent %d masternode entries to %s\n", count, pfrom->addr.ToString().c_str());
-    }
-
-    else if (strCommand == "mnget") { //Masternode Payments Request Sync
+   if (strCommand == "mnget") { //Masternode Payments Request Sync
         if(fLiteMode) return; //disable all darksend/masternode related functionality
 
         /*if(pfrom->HasFulfilledRequest("mnget")) {
@@ -391,166 +100,6 @@ struct CompareValueOnly
         return t1.first < t2.first;
     }
 };
-
-struct CompareValueOnly2
-{
-    bool operator()(const pair<int64_t, int>& t1,
-                    const pair<int64_t, int>& t2) const
-    {
-        return t1.first < t2.first;
-    }
-};
-
-int CountMasternodesAboveProtocol(int protocolVersion)
-{
-    int i = 0;
-
-    BOOST_FOREACH(CMasterNode& mn, vecMasternodes) {
-        if(mn.protocolVersion < protocolVersion) continue;
-        i++;
-    }
-
-    return i;
-
-}
-
-
-int GetMasternodeByVin(CTxIn& vin)
-{
-    int i = 0;
-
-    BOOST_FOREACH(CMasterNode& mn, vecMasternodes) {
-        if (mn.vin == vin) return i;
-        i++;
-    }
-
-    return -1;
-}
-
-bool IsMasternodePaidInList(std::vector<CScript> vecPaidMasternodes, CScript sAddress) {   
-    return std::find(vecPaidMasternodes.begin(), vecPaidMasternodes.end(), sAddress) != vecPaidMasternodes.end();
-}
-
-int GetCurrentMasterNode(int64_t nBlockHeight, int minProtocol)
-{
-    int i = 0;
-    unsigned int score = 0;
-    int winner = -1;
-
-    // masternodes show be payed at most once per day 
-    // and rewards should be shared evenly amongst all contributors
-    // this can be accomplished by checking the last cycle of blocks
-    // and removing all already paid masternodes from the 
-    // winner selection for the next block
-    int count = vecMasternodes.size();
-    count = std::max(count, 960);
-    count = std::min(count, 1500); // limit so we don't cause wallet lockups
-    int iCount = count;
-    std::vector<CScript> vecPaidMasternodes;
-    CBlockIndex* pblockindex = mapBlockIndex[hashBestChain];
-    for (int n = 0; n < count; n++) {
-        CBlock block;
-        if (block.ReadFromDisk(pblockindex)) {
-            if (block.HasMasternodePayment()) {
-                if (block.vtx[1].vout.size() == 3) {
-                    CScript mnScript = block.vtx[1].vout[2].scriptPubKey;
-                    if (!IsMasternodePaidInList(vecPaidMasternodes, mnScript))
-                        vecPaidMasternodes.push_back(mnScript);
-                } else if (block.vtx[1].vout.size() == 4) {
-                    CScript mnScript = block.vtx[1].vout[3].scriptPubKey;
-                    if (!IsMasternodePaidInList(vecPaidMasternodes, mnScript))
-                        vecPaidMasternodes.push_back(mnScript);
-                }
-            }
-        }
-        pblockindex = pblockindex->pprev;  
-    }
-
-    // scan for winner
-    BOOST_FOREACH(CMasterNode mn, vecMasternodes) {
-        CScript mnScript = GetScriptForDestination(mn.pubkey.GetID());
-        if (IsMasternodePaidInList(vecPaidMasternodes, mnScript)) {
-            i++;
-            continue;
-        }
-
-        mn.Check();
-        if(mn.protocolVersion < minProtocol) continue;
-        if(!mn.IsEnabled()) {
-            i++;
-            continue;
-        }
-
-        // calculate the score for each masternode
-        uint256 n = mn.CalculateScore(nBlockHeight);
-        unsigned int n2 = 0;
-        memcpy(&n2, &n, sizeof(n2));
-
-        // determine the winner
-        if(n2 > score) {
-            score = n2;
-            winner = i;
-        }
-        i++;
-    }
-    
-    return winner;
-}
-
-int GetMasternodeByRank(int findRank, int64_t nBlockHeight, int minProtocol)
-{
-    int i = 0;
-
-    std::vector<pair<unsigned int, int> > vecMasternodeScores;
-
-    i = 0;
-    BOOST_FOREACH(CMasterNode mn, vecMasternodes) {
-        mn.Check();
-        if(mn.protocolVersion < minProtocol) continue;
-        if(!mn.IsEnabled()) {
-            i++;
-            continue;
-        }
-
-        uint256 n = mn.CalculateScore(nBlockHeight);
-        unsigned int n2 = 0;
-        memcpy(&n2, &n, sizeof(n2));
-
-        vecMasternodeScores.push_back(make_pair(n2, i));
-        i++;
-    }
-
-    sort(vecMasternodeScores.rbegin(), vecMasternodeScores.rend(), CompareValueOnly2());
-
-    int rank = 0;
-    BOOST_FOREACH (PAIRTYPE(unsigned int, int)& s, vecMasternodeScores){
-        rank++;
-        if(rank == findRank) return s.second;
-    }
-
-    return -1;
-}
-
-int GetMasternodeRank(CTxIn& vin, int64_t nBlockHeight, int minProtocol)
-{
-    std::vector<pair<unsigned int, CTxIn> > vecMasternodeScores = GetMasternodeScores(nBlockHeight, minProtocol);
-    return GetMasternodeRank(vin, vecMasternodeScores);
-}
-
-int GetMasternodeRank(CTxIn& vin, std::vector<pair<unsigned int, CTxIn> >& vecMasternodeScores)
-{
-    unsigned int rank = 0;
-    BOOST_FOREACH (PAIRTYPE(unsigned int, CTxIn)& s, vecMasternodeScores)
-    {
-        rank++;
-        if(s.second == vin) 
-        {
-            return rank;
-        }
-    }
-
-    return -1;
-}
 
 std::vector<pair<unsigned int, CTxIn> > GetMasternodeScores(int64_t nBlockHeight, int minProtocol)
 {
@@ -619,12 +168,72 @@ bool GetBlockHash(uint256& hash, int nBlockHeight)
     return false;
 }
 
+CMasternode::CMasternode()
+{
+    LOCK(cs);
+    vin = CTxIn();
+    addr = CService();
+    pubkey = CPubKey();
+    pubkey2 = CPubKey();
+    sig = std::vector<unsigned char>();
+    activeState = MASTERNODE_ENABLED;
+    now = GetTime();
+    lastDseep = 0;
+    lastTimeSeen = 0;
+    cacheInputAge = 0;
+    cacheInputAgeBlock = 0;
+    unitTest = false;
+    allowFreeTx = true;
+    protocolVersion = MIN_PEER_PROTO_VERSION;
+    nLastDsq = 0;
+}
+
+ CMasternode::CMasternode(const CMasternode& other)
+{
+    LOCK(cs);
+    vin = other.vin;
+    addr = other.addr;
+    pubkey = other.pubkey;
+    pubkey2 = other.pubkey2;
+    sig = other.sig;
+    activeState = other.activeState;
+    now = other.now;
+    lastDseep = other.lastDseep;
+    lastTimeSeen = other.lastTimeSeen;
+    cacheInputAge = other.cacheInputAge;
+    cacheInputAgeBlock = other.cacheInputAgeBlock;
+    unitTest = other.unitTest;
+    allowFreeTx = other.allowFreeTx;
+    protocolVersion = other.protocolVersion;
+    nLastDsq = other.nLastDsq;
+}
+ 
+CMasternode::CMasternode(CService newAddr, CTxIn newVin, CPubKey newPubkey, std::vector<unsigned char> newSig, int64_t newNow, CPubKey newPubkey2, int protocolVersionIn)
+{
+    LOCK(cs);
+    vin = newVin;
+    addr = newAddr;
+    pubkey = newPubkey;
+    pubkey2 = newPubkey2;
+    sig = newSig;
+    activeState = MASTERNODE_ENABLED;
+    now = newNow;
+    lastDseep = 0;
+    lastTimeSeen = 0;
+    cacheInputAge = 0;
+    cacheInputAgeBlock = 0;
+    unitTest = false;
+    allowFreeTx = true;
+    protocolVersion = protocolVersionIn;
+    nLastDsq = 0;
+}
+
 //
 // Deterministically calculate a given "score" for a masternode depending on how close it's hash is to
 // the proof of work for that block. The further away they are the better, the furthest will win the election
 // and get paid this block
 //
-uint256 CMasterNode::CalculateScore(int64_t nBlockHeight)
+uint256 CMasternode::CalculateScore(int64_t nBlockHeight)
 {
     
     if(pindexBest == NULL) return 0;
@@ -648,19 +257,19 @@ uint256 CMasterNode::CalculateScore(int64_t nBlockHeight)
     return r;
 }
 
-void CMasterNode::Check()
+void CMasternode::Check()
 {
     //once spent, stop doing the checks
-    if(enabled==3) return;
+     if(activeState == MASTERNODE_VIN_SPENT) return;
 
 
     if(!UpdatedWithin(MASTERNODE_REMOVAL_SECONDS)){
-        enabled = 4;
+        activeState = MASTERNODE_REMOVE;
         return;
     }
 
     if(!UpdatedWithin(MASTERNODE_EXPIRATION_SECONDS)){
-        enabled = 2;
+        activeState = MASTERNODE_EXPIRED;
         return;
     }
 
@@ -675,12 +284,12 @@ void CMasterNode::Check()
         bool pfMissingInputs = false;
 	    if(!AcceptableInputs(mempool, state, tx, false, &pfMissingInputs))
         {
-            enabled = 3;
+            activeState = MASTERNODE_VIN_SPENT;
             return;
         }
     }
 
-    enabled = 1; // OK
+   activeState = MASTERNODE_ENABLED; // OK
 }
 
 bool CMasternodePayments::CheckSignature(CMasternodePaymentWinner& winner)
@@ -802,7 +411,7 @@ void CMasternodePayments::CleanPaymentList()
 {
     if(pindexBest == NULL) return;
 
-    int nLimit = std::max(((int)vecMasternodes.size())*2, 1000);
+    int nLimit = std::max(((int)mnodeman.size())*2, 1000);
 
     vector<CMasternodePaymentWinner>::iterator it;
     for(it=vWinning.begin();it<vWinning.end();it++){
@@ -828,34 +437,34 @@ bool CMasternodePayments::ProcessBlock(int nBlockHeight)
         if(++c > (int)vecMasternodes.size()) break;
     }
 
-    std::random_shuffle ( vecMasternodes.begin(), vecMasternodes.end() );
-    BOOST_FOREACH(CMasterNode& mn, vecMasternodes) {
-        bool found = false;
-        BOOST_FOREACH(CTxIn& vin, vecLastPayments)
-            if(mn.vin == vin) found = true;
+    CMasternode* mn = mnodeman.FindNotInVec(vecLastPayments);
+    if(mn) 
+    {
+        winner.score = 0;
+        winner.nBlockHeight = nBlockHeight;
+        winner.vin = mn->vin;
+        winner.payee.SetDestination(mn->pubkey.GetID());
+    }
 
-        if(found) continue;
-
-        mn.Check();
-        if(!mn.IsEnabled()) {
-            continue;
+    //if we can't find new MN to get paid, pick first active MN counting back from the end of vecLastPayments list
+   if(winner.nBlockHeight == 0 && mnodeman.size() > 0)
+   {
+	BOOST_REVERSE_FOREACH(CTxIn& vinLP, vecLastPayments)
+		 CMasternode* mn = mnodeman.Find(vinLP);
+            if(mn)
+            {
+                mn->Check();
+                if(!mn->IsEnabled()) continue;
+		    
+                winner.score = 0;
+                winner.nBlockHeight = nBlockHeight;
+                winner.vin = mn->vin;
+                winner.payee.SetDestination(mn->pubkey.GetID());
+                break; // we found active MN
+            }
         }
-
-        winner.score = 0;
-        winner.nBlockHeight = nBlockHeight;
-        winner.vin = mn.vin;
-        winner.payee =GetScriptForDestination(mn.pubkey.GetID());
-
-        break;
     }
-
-    //if we can't find someone to get paid, pick randomly
-    if(winner.nBlockHeight == 0 && vecMasternodes.size() > 0) {
-        winner.score = 0;
-        winner.nBlockHeight = nBlockHeight;
-        winner.vin = vecMasternodes[0].vin;
-        winner.payee =GetScriptForDestination(vecMasternodes[0].pubkey.GetID());
-    }
+    if(newWinner.nBlockHeight == 0) return false;
 
     if(Sign(winner)){
         if(AddWinningMasternode(winner)){

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -18,7 +18,7 @@ map<uint256, int> mapSeenMasternodeScanningErrors;
 // cache block hashes as we calculate them
 std::map<int64_t, uint256> mapCacheBlockHashes;
 
-void ProcessMessageMasternode(CNode* pfrom, std::string& strCommand, CDataStream& vRecv)
+void ProcessMessageMasternodePayments(CNode* pfrom, std::string& strCommand, CDataStream& vRecv)
 {
      if (strCommand == "mnget") { //Masternode Payments Request Sync
         if(fLiteMode) return; //disable all darksend/masternode related functionality

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -18,22 +18,6 @@ map<uint256, int> mapSeenMasternodeScanningErrors;
 // cache block hashes as we calculate them
 std::map<int64_t, uint256> mapCacheBlockHashes;
 
-// manage the masternode connections
-void ProcessMasternodeConnections(){
-    LOCK(cs_vNodes);
-
-    BOOST_FOREACH(CNode* pnode, vNodes)
-    {
-        //if it's our masternode, let it be
-        if(darkSendPool.submittedToMasternode == pnode->addr) continue;
-
-        if(pnode->fDarkSendMaster){
-            LogPrintf("Closing masternode connection %s \n", pnode->addr.ToString().c_str());
-            pnode->CloseSocketDisconnect();
-        }
-    }
-}
-
 void ProcessMessageMasternode(CNode* pfrom, std::string& strCommand, CDataStream& vRecv)
 {
      if (strCommand == "mnget") { //Masternode Payments Request Sync

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -408,7 +408,7 @@ bool CMasternodePayments::ProcessBlock(int nBlockHeight)
     }
 
    //if we can't find new MN to get paid, pick first active MN counting back from the end of vecLastPayments list
-    if(newWinner.nBlockHeight == 0 && mnodeman.size() > 0)
+    if(newWinner.nBlockHeight == 0 && mnodeman.CountEnabled() > 0)
        {
         BOOST_REVERSE_FOREACH(CTxIn& vinLP, vecLastPayments)
 		CMasternode* mn = mnodeman.Find(vinLP);

--- a/src/masternode.h
+++ b/src/masternode.h
@@ -58,7 +58,7 @@ enum masternodeState {
 
 // manage the masternode connections
 void ProcessMasternodeConnections();
-void ProcessMessageMasternode(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
+void ProcessMessageMasternodePayments(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
 
 //
 // The Masternode Class. For managing the darksend process. It contains the input of the 1000Linda, signature to prove

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2014-2015 The Darkcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "masternodeman.h"
 #include "activemasternode.h"
 #include "darksend.h"

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -1,0 +1,521 @@
+#include "masternodeman.h"
+#include "activemasternode.h"
+#include "darksend.h"
+#include "core.h"
+#include "util.h"
+#include "addrman.h"
+#include <boost/lexical_cast.hpp>
+#include <boost/filesystem.hpp>
+ /** Masternode manager */
+CMasternodeMan mnodeman;
+// who's asked for the masternode list and the last time
+std::map<CNetAddr, int64_t> askedForMasternodeList;
+// which masternodes we've asked for
+std::map<COutPoint, int64_t> askedForMasternodeListEntry;
+ struct CompareValueOnly
+{
+    bool operator()(const pair<int64_t, CTxIn>& t1,
+                    const pair<int64_t, CTxIn>& t2) const
+    {
+        return t1.first < t2.first;
+    }
+};
+ //
+// CMasternodeDB
+//
+ CMasternodeDB::CMasternodeDB()
+{
+    pathMN = GetDataDir() / "masternodes.dat";
+}
+ bool CMasternodeDB::Write(const CMasternodeMan& mnodemanToSave)
+{
+    // serialize addresses, checksum data up to that point, then append csum
+    CDataStream ssMasternodes(SER_DISK, CLIENT_VERSION);
+    ssMasternodes << FLATDATA(Params().MessageStart());
+    ssMasternodes << mnodemanToSave;
+    uint256 hash = Hash(ssMasternodes.begin(), ssMasternodes.end());
+    ssMasternodes << hash;
+     // open output file, and associate with CAutoFile
+    FILE *file = fopen(pathMN.string().c_str(), "wb");
+    CAutoFile fileout = CAutoFile(file, SER_DISK, CLIENT_VERSION);
+    if (!fileout)
+        return error("%s : Failed to open file %s", __func__, pathMN.string());
+     // Write and commit header, data
+    try {
+        fileout << ssMasternodes;
+    }
+    catch (std::exception &e) {
+        return error("%s : Serialize or I/O error - %s", __func__, e.what());
+    }
+    FileCommit(fileout);
+    fileout.fclose();
+     return true;
+}
+ bool CMasternodeDB::Read(CMasternodeMan& mnodemanToLoad)
+{
+    // open input file, and associate with CAutoFile
+    FILE *file = fopen(pathMN.string().c_str(), "rb");
+    CAutoFile filein = CAutoFile(file, SER_DISK, CLIENT_VERSION);
+    if (!filein)
+        return error("%s : Failed to open file %s", __func__, pathMN.string());
+     // use file size to size memory buffer
+    int fileSize = boost::filesystem::file_size(pathMN);
+    int dataSize = fileSize - sizeof(uint256);
+    // Don't try to resize to a negative number if file is small
+    if (dataSize < 0)
+        dataSize = 0;
+    vector<unsigned char> vchData;
+    vchData.resize(dataSize);
+    uint256 hashIn;
+     // read data and checksum from file
+    try {
+        filein.read((char *)&vchData[0], dataSize);
+        filein >> hashIn;
+    }
+    catch (std::exception &e) {
+        return error("%s : Deserialize or I/O error - %s", __func__, e.what());
+    }
+    filein.fclose();
+     CDataStream ssMasternodes(vchData, SER_DISK, CLIENT_VERSION);
+     // verify stored checksum matches input data
+    uint256 hashTmp = Hash(ssMasternodes.begin(), ssMasternodes.end());
+    if (hashIn != hashTmp)
+        return error("%s : Checksum mismatch, data corrupted", __func__);
+     unsigned char pchMsgTmp[4];
+    try {
+        // de-serialize file header (network specific magic number) and ..
+        ssMasternodes >> FLATDATA(pchMsgTmp);
+         // ... verify the network matches ours
+        if (memcmp(pchMsgTmp, Params().MessageStart(), sizeof(pchMsgTmp)))
+            return error("%s : Invalid network magic number", __func__);
+         // de-serialize address data into one CMnList object
+        ssMasternodes >> mnodemanToLoad;
+    }
+    catch (std::exception &e) {
+        return error("%s : Deserialize or I/O error - %s", __func__, e.what());
+        mnodemanToLoad.Clear();
+    }
+     return true;
+}
+ void DumpMasternodes()
+{
+    int64_t nStart = GetTimeMillis();
+     CMasternodeDB mndb;
+    mndb.Write(mnodeman);
+     LogPrint("masternode", "Flushed %d masternodes to masternodes.dat  %dms\n",
+           mnodeman.size(), GetTimeMillis() - nStart);
+}
+ CMasternodeMan::CMasternodeMan() {}
+ CMasternode *CMasternodeMan::Find(const CTxIn &vin)
+{
+    LOCK(cs);
+     BOOST_FOREACH(CMasternode& mn, vMasternodes)
+    {
+        if(mn.vin == vin)
+            return &mn;
+    }
+    return NULL;
+}
+ CMasternode *CMasternodeMan::FindRandom()
+{
+    LOCK(cs);
+     if(size() == 0) return NULL;
+     return &vMasternodes[GetRandInt(vMasternodes.size())];
+}
+ CMasternode *CMasternodeMan::FindNotInVec(const std::vector<CTxIn> &vVins)
+{
+    LOCK(cs);
+     BOOST_FOREACH(CMasternode &mn, vMasternodes)
+    {
+        mn.Check();
+        if(!mn.IsEnabled()) continue;
+         bool found = false;
+        BOOST_FOREACH(const CTxIn& vin, vVins)
+            if(mn.vin == vin)
+            {
+                found = true;
+                break;
+            }
+         if(found) continue;
+         return &mn;
+    }
+     return NULL;
+}
+ bool CMasternodeMan::Add(CMasternode &mn)
+{
+    LOCK(cs);
+     if (!mn.IsEnabled())
+        return false;
+     CMasternode *pmn = Find(mn.vin);
+     if (!pmn)
+    {
+        vMasternodes.push_back(mn);
+        return true;
+    }
+     return false;
+}
+ void CMasternodeMan::Check()
+{
+    LOCK(cs);
+     BOOST_FOREACH(CMasternode& mn, vMasternodes)
+        mn.Check();
+}
+ void CMasternodeMan::CheckAndRemove()
+{
+    LOCK(cs);
+     vector<CMasternode>::iterator it = vMasternodes.begin();
+    //check them separately
+    while(it != vMasternodes.end()){
+        (*it).Check();
+        ++it;
+    }
+     //remove inactive
+    it = vMasternodes.begin();
+    while(it != vMasternodes.end()){
+        if((*it).activeState == 4 || (*it).activeState == 3){
+            LogPrintf("Removing inactive masternode %s\n", (*it).addr.ToString().c_str());
+            it = vMasternodes.erase(it);
+        } else {
+            ++it;
+        }
+    }
+}
+ int CMasternodeMan::CountMasternodesAboveProtocol(int protocolVersion)
+{
+    int i = 0;
+     BOOST_FOREACH(CMasternode& mn, vMasternodes) {
+        if(mn.protocolVersion < protocolVersion || !mn.IsEnabled()) continue;
+        i++;
+    }
+     return i;
+}
+ int CMasternodeMan::CountEnabled()
+{
+    int i = 0;
+     BOOST_FOREACH(CMasternode& mn, vMasternodes) {
+        if(!mn.IsEnabled()) continue;
+        i++;
+    }
+     return i;
+}
+ CMasternode* CMasternodeMan::GetCurrentMasterNode(int mod, int64_t nBlockHeight, int minProtocol)
+{
+    unsigned int score = 0;
+    CMasternode* winner = NULL;
+     // scan for winner
+    BOOST_FOREACH(CMasternode& mn, vMasternodes) {
+        mn.Check();
+        if(mn.protocolVersion < minProtocol || !mn.IsEnabled()) continue;
+         // calculate the score for each masternode
+        uint256 n = mn.CalculateScore(mod, nBlockHeight);
+        unsigned int n2 = 0;
+        memcpy(&n2, &n, sizeof(n2));
+         // determine the winner
+        if(n2 > score){
+            score = n2;
+            winner = &mn;
+        }
+    }
+     return winner;
+}
+ int CMasternodeMan::GetMasternodeRank(const CTxIn& vin, int64_t nBlockHeight, int minProtocol)
+{
+    std::vector<pair<unsigned int, CTxIn> > vecMasternodeScores;
+     // scan for winner
+    BOOST_FOREACH(CMasternode& mn, vMasternodes) {
+         mn.Check();
+         if(mn.protocolVersion < minProtocol) continue;
+        if(!mn.IsEnabled()) {
+            continue;
+        }
+         uint256 n = mn.CalculateScore(1, nBlockHeight);
+        unsigned int n2 = 0;
+        memcpy(&n2, &n, sizeof(n2));
+         vecMasternodeScores.push_back(make_pair(n2, mn.vin));
+    }
+     sort(vecMasternodeScores.rbegin(), vecMasternodeScores.rend(), CompareValueOnly());
+     unsigned int rank = 0;
+    BOOST_FOREACH (PAIRTYPE(unsigned int, CTxIn)& s, vecMasternodeScores){
+        rank++;
+        if(s.second == vin) {
+            return rank;
+        }
+    }
+     return -1;
+}
+ json_spirit::Object CMasternodeMan::GetFilteredVector(std::string strMode, std::string strFilter)
+{
+    using namespace json_spirit;
+    Object obj;
+    BOOST_FOREACH(CMasternode& mn, vMasternodes) {
+        mn.Check();
+         std::string strAddr = mn.addr.ToString().c_str();
+        if(strMode == "active"){
+            if(strFilter !="" && stoi(strFilter) != mn.IsEnabled()) continue;
+            obj.push_back(Pair(strAddr,       (int)mn.IsEnabled()));
+        } else if (strMode == "vin") {
+            if(strFilter !="" && mn.vin.prevout.hash.ToString().find(strFilter) == string::npos) continue;
+            obj.push_back(Pair(strAddr,       mn.vin.prevout.hash.ToString().c_str()));
+        } else if (strMode == "pubkey") {
+            CScript pubkey;
+            pubkey.SetDestination(mn.pubkey.GetID());
+            CTxDestination address1;
+            ExtractDestination(pubkey, address1);
+            CBitcoinAddress address2(address1);
+             if(strFilter !="" && address2.ToString().find(strFilter) == string::npos) continue;
+            obj.push_back(Pair(strAddr,       address2.ToString().c_str()));
+        } else if (strMode == "protocol") {
+            if(strFilter !="" && stoi(strFilter) != mn.protocolVersion) continue;
+            obj.push_back(Pair(strAddr,       (int64_t)mn.protocolVersion));
+        } else if (strMode == "lastseen") {
+            obj.push_back(Pair(strAddr,       (int64_t)mn.lastTimeSeen));
+        } else if (strMode == "activeseconds") {
+            obj.push_back(Pair(strAddr,       (int64_t)(mn.lastTimeSeen - mn.now)));
+        } else if (strMode == "rank") {
+            obj.push_back(Pair(strAddr,       (int)(mnodeman.GetMasternodeRank(mn.vin, chainActive.Tip()->nHeight))));
+        } else if (strMode == "full") {
+            CScript pubkey;
+            pubkey.SetDestination(mn.pubkey.GetID());
+            CTxDestination address1;
+            ExtractDestination(pubkey, address1);
+            CBitcoinAddress address2(address1);
+             std::ostringstream stringStream;
+            stringStream << (mn.IsEnabled() ? "1" : "0") << " | " <<
+                           mn.protocolVersion << " | " <<
+                           address2.ToString() << " | " <<
+                           mn.vin.prevout.hash.ToString() << " | " <<
+                           mn.lastTimeSeen << " | " <<
+                           (mn.lastTimeSeen - mn.now);
+            std::string output = stringStream.str();
+            stringStream << " " << strAddr;
+            if(strFilter !="" && stringStream.str().find(strFilter) == string::npos) continue;
+            obj.push_back(Pair(strAddr, output));
+        }
+    }
+    return obj;
+}
+ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CDataStream& vRecv)
+{
+     if(fLiteMode) return; //disable all darksend/masternode related functionality
+    if(IsInitialBlockDownload()) return;
+     LOCK(cs);
+     if (strCommand == "dsee") { //DarkSend Election Entry
+         CTxIn vin;
+        CService addr;
+        CPubKey pubkey;
+        CPubKey pubkey2;
+        vector<unsigned char> vchSig;
+        int64_t sigTime;
+        int count;
+        int current;
+        int64_t lastUpdated;
+        int protocolVersion;
+        std::string strMessage;
+         // 70047 and greater
+        vRecv >> vin >> addr >> vchSig >> sigTime >> pubkey >> pubkey2 >> count >> current >> lastUpdated >> protocolVersion;
+         // make sure signature isn't in the future (past is OK)
+        if (sigTime > GetAdjustedTime() + 60 * 60) {
+            LogPrintf("dsee - Signature rejected, too far into the future %s\n", vin.ToString().c_str());
+            return;
+        }
+         bool isLocal = addr.IsRFC1918() || addr.IsLocal();
+        if(RegTest()) isLocal = false;
+         std::string vchPubKey(pubkey.begin(), pubkey.end());
+        std::string vchPubKey2(pubkey2.begin(), pubkey2.end());
+         strMessage = addr.ToString() + boost::lexical_cast<std::string>(sigTime) + vchPubKey + vchPubKey2 + boost::lexical_cast<std::string>(protocolVersion);
+         if(protocolVersion < nMasternodeMinProtocol) {
+            LogPrintf("dsee - ignoring outdated masternode %s protocol version %d\n", vin.ToString().c_str(), protocolVersion);
+            return;
+        }
+         CScript pubkeyScript;
+        pubkeyScript.SetDestination(pubkey.GetID());
+         if(pubkeyScript.size() != 25) {
+            LogPrintf("dsee - pubkey the wrong size\n");
+            Misbehaving(pfrom->GetId(), 100);
+            return;
+        }
+         CScript pubkeyScript2;
+        pubkeyScript2.SetDestination(pubkey2.GetID());
+         if(pubkeyScript2.size() != 25) {
+            LogPrintf("dsee - pubkey2 the wrong size\n");
+            Misbehaving(pfrom->GetId(), 100);
+            return;
+        }
+         std::string errorMessage = "";
+        if(!darkSendSigner.VerifyMessage(pubkey, vchSig, strMessage, errorMessage)){
+            LogPrintf("dsee - Got bad masternode address signature\n");
+            Misbehaving(pfrom->GetId(), 100);
+            return;
+        }
+         if(Params().NetworkID() == CChainParams::MAIN){
+            if(addr.GetPort() != 9999) return;
+        }
+         //search existing masternode list, this is where we update existing masternodes with new dsee broadcasts
+        CMasternode* mn = this->Find(vin);
+        if(mn)
+        {
+            // count == -1 when it's a new entry
+            //   e.g. We don't want the entry relayed/time updated when we're syncing the list
+            // mn.pubkey = pubkey, IsVinAssociatedWithPubkey is validated once below,
+            //   after that they just need to match
+            if(count == -1 && mn->pubkey == pubkey && !mn->UpdatedWithin(MASTERNODE_MIN_DSEE_SECONDS)){
+                mn->UpdateLastSeen();
+                 if(mn->now < sigTime){ //take the newest entry
+                    LogPrintf("dsee - Got updated entry for %s\n", addr.ToString().c_str());
+                    mn->pubkey2 = pubkey2;
+                    mn->now = sigTime;
+                    mn->sig = vchSig;
+                    mn->protocolVersion = protocolVersion;
+                    mn->addr = addr;
+                    mn->Check();
+                    if(mn->IsEnabled())
+                        RelayDarkSendElectionEntry(vin, addr, vchSig, sigTime, pubkey, pubkey2, count, current, lastUpdated, protocolVersion);
+                }
+            }
+             return;
+        }
+         // make sure the vout that was signed is related to the transaction that spawned the masternode
+        //  - this is expensive, so it's only done once per masternode
+        if(!darkSendSigner.IsVinAssociatedWithPubkey(vin, pubkey)) {
+            LogPrintf("dsee - Got mismatched pubkey and vin\n");
+            Misbehaving(pfrom->GetId(), 100);
+            return;
+        }
+         if(fDebug) LogPrintf("dsee - Got NEW masternode entry %s\n", addr.ToString().c_str());
+         // make sure it's still unspent
+        //  - this is checked later by .check() in many places and by ThreadCheckDarkSendPool()
+         CValidationState state;
+        CTransaction tx = CTransaction();
+        CTxOut vout = CTxOut(999.99*COIN, darkSendPool.collateralPubKey);
+        tx.vin.push_back(vin);
+        tx.vout.push_back(vout);
+        if(AcceptableInputs(mempool, state, tx)){
+            if(fDebug) LogPrintf("dsee - Accepted masternode entry %i %i\n", count, current);
+             if(GetInputAge(vin) < MASTERNODE_MIN_CONFIRMATIONS){
+                LogPrintf("dsee - Input must have least %d confirmations\n", MASTERNODE_MIN_CONFIRMATIONS);
+                Misbehaving(pfrom->GetId(), 20);
+                return;
+            }
+             // use this as a peer
+            addrman.Add(CAddress(addr), pfrom->addr, 2*60*60);
+             // add our masternode
+            CMasternode mn(addr, vin, pubkey, vchSig, sigTime, pubkey2, protocolVersion);
+            mn.UpdateLastSeen(lastUpdated);
+            this->Add(mn);
+             // if it matches our masternodeprivkey, then we've been remotely activated
+            if(pubkey2 == activeMasternode.pubKeyMasternode && protocolVersion == PROTOCOL_VERSION){
+                activeMasternode.EnableHotColdMasterNode(vin, addr);
+            }
+             if(count == -1 && !isLocal)
+                RelayDarkSendElectionEntry(vin, addr, vchSig, sigTime, pubkey, pubkey2, count, current, lastUpdated, protocolVersion);
+         } else {
+            LogPrintf("dsee - Rejected masternode entry %s\n", addr.ToString().c_str());
+             int nDoS = 0;
+            if (state.IsInvalid(nDoS))
+            {
+                LogPrintf("dsee - %s from %s %s was not accepted into the memory pool\n", tx.GetHash().ToString().c_str(),
+                    pfrom->addr.ToString().c_str(), pfrom->cleanSubVer.c_str());
+                if (nDoS > 0)
+                    Misbehaving(pfrom->GetId(), nDoS);
+            }
+        }
+    }
+     else if (strCommand == "dseep") { //DarkSend Election Entry Ping
+         CTxIn vin;
+        vector<unsigned char> vchSig;
+        int64_t sigTime;
+        bool stop;
+        vRecv >> vin >> vchSig >> sigTime >> stop;
+         //LogPrintf("dseep - Received: vin: %s sigTime: %lld stop: %s\n", vin.ToString().c_str(), sigTime, stop ? "true" : "false");
+         if (sigTime > GetAdjustedTime() + 60 * 60) {
+            LogPrintf("dseep - Signature rejected, too far into the future %s\n", vin.ToString().c_str());
+            return;
+        }
+         if (sigTime <= GetAdjustedTime() - 60 * 60) {
+            LogPrintf("dseep - Signature rejected, too far into the past %s - %d %d \n", vin.ToString().c_str(), sigTime, GetAdjustedTime());
+            return;
+        }
+         // see if we have this masternode
+        CMasternode* mn = this->Find(vin);
+        if(mn)
+        {
+            // LogPrintf("dseep - Found corresponding mn for vin: %s\n", vin.ToString().c_str());
+            // take this only if it's newer
+            if(mn->lastDseep < sigTime)
+            {
+                std::string strMessage = mn->addr.ToString() + boost::lexical_cast<std::string>(sigTime) + boost::lexical_cast<std::string>(stop);
+                 std::string errorMessage = "";
+                if(!darkSendSigner.VerifyMessage(mn->pubkey2, vchSig, strMessage, errorMessage))
+                {
+                    LogPrintf("dseep - Got bad masternode address signature %s \n", vin.ToString().c_str());
+                    //Misbehaving(pfrom->GetId(), 100);
+                    return;
+                }
+                 mn->lastDseep = sigTime;
+                 if(!mn->UpdatedWithin(MASTERNODE_MIN_DSEEP_SECONDS))
+                {
+                    if(stop) mn->Disable();
+                    else
+                    {
+                        mn->UpdateLastSeen();
+                        mn->Check();
+                        if(!mn->IsEnabled()) return;
+                    }
+                    RelayDarkSendElectionEntryPing(vin, vchSig, sigTime, stop);
+                }
+            }
+            return;
+        }
+         if(fDebug) LogPrintf("dseep - Couldn't find masternode entry %s\n", vin.ToString().c_str());
+         std::map<COutPoint, int64_t>::iterator i = askedForMasternodeListEntry.find(vin.prevout);
+        if (i != askedForMasternodeListEntry.end())
+        {
+            int64_t t = (*i).second;
+            if (GetTime() < t) return; // we've asked recently
+        }
+         // ask for the dsee info once from the node that sent dseep
+         LogPrintf("dseep - Asking source node for missing entry %s\n", vin.ToString().c_str());
+        pfrom->PushMessage("dseg", vin);
+        int64_t askAgain = GetTime()+(60*60*24);
+        askedForMasternodeListEntry[vin.prevout] = askAgain;
+     } else if (strCommand == "dseg") { //Get masternode list or specific entry
+         CTxIn vin;
+        vRecv >> vin;
+         if(vin == CTxIn()) { //only should ask for this once
+            //local network
+            if(!pfrom->addr.IsRFC1918() && Params().NetworkID() == CChainParams::MAIN)
+            {
+                std::map<CNetAddr, int64_t>::iterator i = askedForMasternodeList.find(pfrom->addr);
+                if (i != askedForMasternodeList.end())
+                {
+                    int64_t t = (*i).second;
+                    if (GetTime() < t) {
+                        Misbehaving(pfrom->GetId(), 34);
+                        LogPrintf("dseg - peer already asked me for the list\n");
+                        return;
+                    }
+                }
+                 int64_t askAgain = GetTime()+(60*60*3);
+                askedForMasternodeList[pfrom->addr] = askAgain;
+            }
+        } //else, asking for a specific node which is ok
+         int count = this->size();
+        int i = 0;
+         BOOST_FOREACH(CMasternode& mn, vMasternodes) {
+             if(mn.addr.IsRFC1918()) continue; //local network
+             if(mn.IsEnabled())
+            {
+                if(fDebug) LogPrintf("dseg - Sending masternode entry - %s \n", mn.addr.ToString().c_str());
+                if(vin == CTxIn()){
+                    pfrom->PushMessage("dsee", mn.vin, mn.addr, mn.sig, mn.now, mn.pubkey, mn.pubkey2, count, i, mn.lastTimeSeen, mn.protocolVersion);
+                } else if (vin == mn.vin) {
+                    pfrom->PushMessage("dsee", mn.vin, mn.addr, mn.sig, mn.now, mn.pubkey, mn.pubkey2, count, i, mn.lastTimeSeen, mn.protocolVersion);
+                    LogPrintf("dseg - Sent 1 masternode entries to %s\n", pfrom->addr.ToString().c_str());
+                    return;
+                }
+                i++;
+            }
+        }
+         LogPrintf("dseg - Sent %d masternode entries to %s\n", i, pfrom->addr.ToString().c_str());
+    }
+ }

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -243,57 +243,7 @@ std::map<COutPoint, int64_t> askedForMasternodeListEntry;
     }
      return -1;
 }
- json_spirit::Object CMasternodeMan::GetFilteredVector(std::string strMode, std::string strFilter)
-{
-    using namespace json_spirit;
-    Object obj;
-    BOOST_FOREACH(CMasternode& mn, vMasternodes) {
-        mn.Check();
-         std::string strAddr = mn.addr.ToString().c_str();
-        if(strMode == "active"){
-            if(strFilter !="" && stoi(strFilter) != mn.IsEnabled()) continue;
-            obj.push_back(Pair(strAddr,       (int)mn.IsEnabled()));
-        } else if (strMode == "vin") {
-            if(strFilter !="" && mn.vin.prevout.hash.ToString().find(strFilter) == string::npos) continue;
-            obj.push_back(Pair(strAddr,       mn.vin.prevout.hash.ToString().c_str()));
-        } else if (strMode == "pubkey") {
-            CScript pubkey;
-            pubkey.SetDestination(mn.pubkey.GetID());
-            CTxDestination address1;
-            ExtractDestination(pubkey, address1);
-            CBitcoinAddress address2(address1);
-             if(strFilter !="" && address2.ToString().find(strFilter) == string::npos) continue;
-            obj.push_back(Pair(strAddr,       address2.ToString().c_str()));
-        } else if (strMode == "protocol") {
-            if(strFilter !="" && stoi(strFilter) != mn.protocolVersion) continue;
-            obj.push_back(Pair(strAddr,       (int64_t)mn.protocolVersion));
-        } else if (strMode == "lastseen") {
-            obj.push_back(Pair(strAddr,       (int64_t)mn.lastTimeSeen));
-        } else if (strMode == "activeseconds") {
-            obj.push_back(Pair(strAddr,       (int64_t)(mn.lastTimeSeen - mn.now)));
-        } else if (strMode == "rank") {
-            obj.push_back(Pair(strAddr,       (int)(mnodeman.GetMasternodeRank(mn.vin, chainActive.Tip()->nHeight))));
-        } else if (strMode == "full") {
-            CScript pubkey;
-            pubkey.SetDestination(mn.pubkey.GetID());
-            CTxDestination address1;
-            ExtractDestination(pubkey, address1);
-            CBitcoinAddress address2(address1);
-             std::ostringstream stringStream;
-            stringStream << (mn.IsEnabled() ? "1" : "0") << " | " <<
-                           mn.protocolVersion << " | " <<
-                           address2.ToString() << " | " <<
-                           mn.vin.prevout.hash.ToString() << " | " <<
-                           mn.lastTimeSeen << " | " <<
-                           (mn.lastTimeSeen - mn.now);
-            std::string output = stringStream.str();
-            stringStream << " " << strAddr;
-            if(strFilter !="" && stringStream.str().find(strFilter) == string::npos) continue;
-            obj.push_back(Pair(strAddr, output));
-        }
-    }
-    return obj;
-}
+ 
  void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CDataStream& vRecv)
 {
      if(fLiteMode) return; //disable all darksend/masternode related functionality

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -19,6 +19,7 @@
 #include "json/json_spirit_value.h"
 
  #define MASTERNODES_DUMP_SECONDS               (15*60)
+ #define MASTERNODE_PING_WAIT_SECONDS           (5*60)
  
  using namespace std;
  

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -1,0 +1,111 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2012 The Bitcoin developers
+// Distributed under the MIT/X11 software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef MASTERNODEMAN_H
+#define MASTERNODEMAN_H
+
+ #include "bignum.h"
+#include "sync.h"
+#include "net.h"
+#include "key.h"
+#include "core.h"
+#include "util.h"
+#include "script.h"
+#include "base58.h"
+#include "main.h"
+#include "masternode.h"
+#include "json/json_spirit_value.h"
+
+ #define MASTERNODES_DUMP_SECONDS               (15*60)
+ 
+ using namespace std;
+ 
+ class CMasternodeMan;
+ 
+ extern CMasternodeMan mnodeman;
+extern std::vector<CTxIn> vecMasternodeAskedFor;
+extern map<uint256, CMasternodePaymentWinner> mapSeenMasternodeVotes;
+extern map<int64_t, uint256> mapCacheBlockHashes;
+
+ void DumpMasternodes();
+ 
+ /** Access to the MN database (masternodes.dat) */
+class CMasternodeDB
+{
+private:
+    boost::filesystem::path pathMN;
+public:
+    CMasternodeDB();
+    bool Write(const CMasternodeMan &mnodemanToSave);
+    bool Read(CMasternodeMan& mnodemanToLoad);
+};
+
+ class CMasternodeMan
+{
+private:
+    // critical section to protect the inner data structures
+    mutable CCriticalSection cs;
+    
+     // map to hold all MNs
+    std::vector<CMasternode> vMasternodes;
+    
+ public:
+ 
+     IMPLEMENT_SERIALIZE
+    (
+        // serialized format:
+        // * version byte (currently 0)
+        // * masternodes vector
+        {
+                LOCK(cs);
+                unsigned char nVersion = 0;
+                READWRITE(nVersion);
+                READWRITE(vMasternodes);
+        }
+    )
+    
+     CMasternodeMan();
+    CMasternodeMan(CMasternodeMan& other);
+    
+     // Find an entry
+    CMasternode* Find(const CTxIn& vin);
+    
+     // Find a random entry
+    CMasternode* FindRandom();
+    
+     //Find an entry thta do not match every entry provided vector
+    CMasternode* FindNotInVec(const std::vector<CTxIn> &vVins);
+    
+     // Add an entry
+    bool Add(CMasternode &mn);
+    
+     // Check all masternodes
+    void Check();
+    
+     // Check all masternodes and remove inactive
+    void CheckAndRemove();
+    
+     // Clear masternode vector
+    void Clear() { vMasternodes.clear(); }
+    
+     // Return the number of (unique) masternodes
+    int size() { return vMasternodes.size(); }
+    
+     // Get the current winner for this block
+    CMasternode* GetCurrentMasterNode(int mod=1, int64_t nBlockHeight=0, int minProtocol=0);
+    
+     int GetMasternodeRank(const CTxIn &vin, int64_t nBlockHeight, int minProtocol=0);
+     
+     int CountMasternodesAboveProtocol(int protocolVersion);
+     
+     int CountEnabled();
+     
+     json_spirit::Object GetFilteredVector(std::string strMode, std::string strFilter);
+     
+     void ProcessMessage(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
+     
+ };
+ 
+ #endif

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -16,7 +16,6 @@
 #include "base58.h"
 #include "main.h"
 #include "masternode.h"
-#include "json/json_spirit_value.h"
 
  #define MASTERNODES_DUMP_SECONDS               (15*60)
  #define MASTERNODE_PING_WAIT_SECONDS           (5*60)
@@ -103,7 +102,7 @@ private:
      
      int CountEnabled();
      
-     json_spirit::Object GetFilteredVector(std::string strMode, std::string strFilter);
+     std::vector<CMasternode> GetFullMasternodeVector() { return vMasternodes; }
      
      void ProcessMessage(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
      

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -1,5 +1,4 @@
-// Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2012 The Bitcoin developers
+// Copyright (c) 2014-2015 The Darkcoin developers
 // Distributed under the MIT/X11 software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 

--- a/src/masternodeman.h
+++ b/src/masternodeman.h
@@ -50,6 +50,10 @@ private:
     
      // map to hold all MNs
     std::vector<CMasternode> vMasternodes;
+  
+    // keep track of latest time whem vMasternodes was changed
+    int64_t lastTimeChanged;
+
     
  public:
  
@@ -62,6 +66,7 @@ private:
                 LOCK(cs);
                 unsigned char nVersion = 0;
                 READWRITE(nVersion);
+                READWRITE(lastTimeChanged);
                 READWRITE(vMasternodes);
         }
     )
@@ -88,7 +93,7 @@ private:
     void CheckAndRemove();
     
      // Clear masternode vector
-    void Clear() { vMasternodes.clear(); }
+    void Clear() { vMasternodes.clear(); lastTimeChanged = 0; }
     
      // Return the number of (unique) masternodes
     int size() { return vMasternodes.size(); }
@@ -102,9 +107,13 @@ private:
      
      int CountEnabled();
      
-     std::vector<CMasternode> GetFullMasternodeVector() { return vMasternodes; }
+     std::vector<CMasternode> GetFullMasternodeVector() { Check(); return vMasternodes; }
      
      void ProcessMessage(CNode* pfrom, std::string& strCommand, CDataStream& vRecv);
+  
+     void UpdateLastTimeChanged() { lastTimeChanged = GetAdjustedTime(); }
+  
+     bool UpdateNeeded() { return lastTimeChanged < GetAdjustedTime() - MASTERNODE_REMOVAL_SECONDS; }
      
  };
  

--- a/src/rpcdarksend.cpp
+++ b/src/rpcdarksend.cpp
@@ -7,7 +7,7 @@
 //#include "primitives/transaction.h"
 #include "db.h"
 #include "init.h"
-#include "masternode.h"
+#include "masternodeman.h"
 #include "activemasternode.h"
 #include "masternodeconfig.h"
 #include "rpcserver.h"
@@ -111,7 +111,7 @@ Value getpoolinfo(const Array& params, bool fHelp)
             "Returns an object containing anonymous pool-related information.");
 
     Object obj;
-    obj.push_back(Pair("current_masternode",        GetCurrentMasterNode()));
+    obj.push_back(Pair("current_masternode",        mnodeman.GetCurrentMasterNode()->addr.ToString()));
     obj.push_back(Pair("state",        darkSendPool.GetState()));
     obj.push_back(Pair("entries",      darkSendPool.GetEntriesCount()));
     obj.push_back(Pair("entries_accepted",      darkSendPool.GetCountEntriesAccepted()));

--- a/src/rpcdarksend.cpp
+++ b/src/rpcdarksend.cpp
@@ -717,5 +717,56 @@ Value masternodelist(const Array& params, bool fHelp)
                 "  vin            - Print vin associated with a masternode (can be filtered, partial match)\n"
                 );
     }
-     return mnodeman.GetFilteredVector(strMode, strFilter);
+    Object obj;
+    std::vector<CMasternode> vMasternodes = mnodeman.GetFullMasternodeVector();
+    BOOST_FOREACH(CMasternode& mn, vMasternodes) {
+        mn.Check();
+	    
+         std::string strAddr = mn.addr.ToString().c_str();
+        if(strMode == "active"){
+            if(strFilter !="" && stoi(strFilter) != mn.IsEnabled()) continue;
+            obj.push_back(Pair(strAddr,       (int)mn.IsEnabled()));
+        } else if (strMode == "vin") {
+            if(strFilter !="" && mn.vin.prevout.hash.ToString().find(strFilter) == string::npos) continue;
+            obj.push_back(Pair(strAddr,       mn.vin.prevout.hash.ToString().c_str()));
+        } else if (strMode == "pubkey") {
+            CScript pubkey;
+            pubkey.SetDestination(mn.pubkey.GetID());
+            CTxDestination address1;
+            ExtractDestination(pubkey, address1);
+            CBitcoinAddress address2(address1);
+		
+             if(strFilter !="" && address2.ToString().find(strFilter) == string::npos) continue;
+            obj.push_back(Pair(strAddr,       address2.ToString().c_str()));
+        } else if (strMode == "protocol") {
+            if(strFilter !="" && stoi(strFilter) != mn.protocolVersion) continue;
+            obj.push_back(Pair(strAddr,       (int64_t)mn.protocolVersion));
+        } else if (strMode == "lastseen") {
+            obj.push_back(Pair(strAddr,       (int64_t)mn.lastTimeSeen));
+        } else if (strMode == "activeseconds") {
+            obj.push_back(Pair(strAddr,       (int64_t)(mn.lastTimeSeen - mn.now)));
+        } else if (strMode == "rank") {
+            obj.push_back(Pair(strAddr,       (int)(mnodeman.GetMasternodeRank(mn.vin, chainActive.Tip()->nHeight))));
+        } else if (strMode == "full") {
+            CScript pubkey;
+            pubkey.SetDestination(mn.pubkey.GetID());
+            CTxDestination address1;
+            ExtractDestination(pubkey, address1);
+            CBitcoinAddress address2(address1);
+		
+            std::ostringstream stringStream;
+            stringStream << (mn.IsEnabled() ? "1" : "0") << " | " <<
+                           mn.protocolVersion << " | " <<
+                           address2.ToString() << " | " <<
+                           mn.vin.prevout.hash.ToString() << " | " <<
+                           mn.lastTimeSeen << " | " <<
+                           (mn.lastTimeSeen - mn.now);
+            std::string output = stringStream.str();
+            stringStream << " " << strAddr;
+            if(strFilter !="" && stringStream.str().find(strFilter) == string::npos) continue;
+            obj.push_back(Pair(strAddr, output));
+        }
+    }
+    return obj;
+
 }

--- a/src/rpcdarksend.cpp
+++ b/src/rpcdarksend.cpp
@@ -274,46 +274,21 @@ Value masternode(const Array& params, bool fHelp)
 
     if (strCommand == "list")
     {
-        std::string strCommand = "active";
-
-        if (params.size() == 2){
-            strCommand = params[1].get_str().c_str();
-        }
-
-        if (strCommand != "active" && strCommand != "vin" && strCommand != "pubkey" && strCommand != "lastseen" && strCommand != "activeseconds" && strCommand != "rank" && strCommand != "protocol"){
-            throw runtime_error(
-                "list supports 'active', 'vin', 'pubkey', 'lastseen', 'activeseconds', 'rank', 'protocol'\n");
-        }
-
-        Object obj;
-        BOOST_FOREACH(CMasterNode mn, vecMasternodes) {
-            mn.Check();
-
-            if(strCommand == "active"){
-                obj.push_back(Pair(mn.addr.ToString().c_str(),       (int)mn.IsEnabled()));
-            } else if (strCommand == "vin") {
-                obj.push_back(Pair(mn.addr.ToString().c_str(),       mn.vin.prevout.hash.ToString().c_str()));
-            } else if (strCommand == "pubkey") {
-                CScript pubkey;
-                pubkey =GetScriptForDestination(mn.pubkey.GetID());
-                CTxDestination address1;
-                ExtractDestination(pubkey, address1);
-                CBitcoinAddress address2(address1);
-
-                obj.push_back(Pair(mn.addr.ToString().c_str(),       address2.ToString().c_str()));
-            } else if (strCommand == "protocol") {
-                obj.push_back(Pair(mn.addr.ToString().c_str(),       (int64_t)mn.protocolVersion));
-            } else if (strCommand == "lastseen") {
-                obj.push_back(Pair(mn.addr.ToString().c_str(),       (int64_t)mn.lastTimeSeen));
-            } else if (strCommand == "activeseconds") {
-                obj.push_back(Pair(mn.addr.ToString().c_str(),       (int64_t)(mn.lastTimeSeen - mn.now)));
-            } else if (strCommand == "rank") {
-                obj.push_back(Pair(mn.addr.ToString().c_str(),       (int)(GetMasternodeRank(mn.vin, pindexBest->nHeight))));
-            }
-        }
-        return obj;
+        Array newParams(params.size() - 1);
+        std::copy(params.begin() + 1, params.end(), newParams.begin());
+        return masternodelist(newParams, fHelp);
     }
-    if (strCommand == "count") return (int)vecMasternodes.size();
+
+         if (strCommand == "count")
+    {
+        if (params.size() > 2){
+            throw runtime_error(
+                "too many parameters\n");
+        }
+		 
+ if (params.size() == 2) return mnodeman.CountEnabled();
+        return mnodeman.size();	 
+    }
 
     if (strCommand == "start")
     {
@@ -518,9 +493,9 @@ Value masternode(const Array& params, bool fHelp)
 
     if (strCommand == "current")
     {
-        int winner = GetCurrentMasterNode();
-        if(winner >= 0) {
-            return vecMasternodes[winner].addr.ToString().c_str();
+        CMasternode* winner = mnodeman.GetCurrentMasterNode(1);
+        if(winner) {
+            return winner->addr.ToString().c_str();
         }
 
         return "unknown";
@@ -715,3 +690,32 @@ Value masternode(const Array& params, bool fHelp)
     return Value::null;
 }
 
+Value masternodelist(const Array& params, bool fHelp)
+{
+    std::string strMode = "active";
+    std::string strFilter = "";
+     if (params.size() >= 1) strMode = params[0].get_str();
+    if (params.size() == 2) strFilter = params[1].get_str();
+     if (fHelp ||
+            (strMode != "active" && strMode != "vin" && strMode != "pubkey" && strMode != "lastseen"
+             && strMode != "activeseconds" && strMode != "rank" && strMode != "protocol" && strMode != "full"))
+    {
+        throw runtime_error(
+                "masternodelist ( \"mode\" \"filter\" )\n"
+                "Get a list of masternodes in different modes\n"
+                "\nArguments:\n"
+                "1. \"mode\"      (string, optional, defauls = active) The mode to run list in\n"
+                "2. \"filter\"    (string, optional) Filter results, can be applied in few modes only\n"
+                "Available modes:\n"
+                "  active         - Print '1' if active and '0' otherwise (can be filtered, exact match)\n"
+                "  activeseconds  - Print number of seconds masternode recognized by the network as enabled\n"
+                "  full           - Print info in format 'active | protocol | pubkey | vin | lastseen | activeseconds' (can be filtered, partial match)\n"
+                "  lastseen       - Print timestamp of when a masternode was last seen on the network\n"
+                "  protocol       - Print protocol of a masternode (can be filtered, exact match)\n"
+                "  pubkey         - Print public key associated with a masternode (can be filtered, partial match)\n"
+                "  rank           - Print rank of a masternode based on current block\n"
+                "  vin            - Print vin associated with a masternode (can be filtered, partial match)\n"
+                );
+    }
+     return mnodeman.GetFilteredVector(strMode, strFilter);
+}

--- a/src/rpcdarksend.cpp
+++ b/src/rpcdarksend.cpp
@@ -720,8 +720,7 @@ Value masternodelist(const Array& params, bool fHelp)
     Object obj;
     std::vector<CMasternode> vMasternodes = mnodeman.GetFullMasternodeVector();
     BOOST_FOREACH(CMasternode& mn, vMasternodes) {
-        mn.Check();
-	    
+           
          std::string strAddr = mn.addr.ToString().c_str();
         if(strMode == "active"){
             if(strFilter !="" && stoi(strFilter) != mn.IsEnabled()) continue;

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -258,6 +258,7 @@ static const CRPCCommand vRPCCommands[] =
     { "darksend",               &darksend,               false,     false,      true },
     { "spork",                  &spork,                  true,      false,      false },
     { "masternode",             &masternode,             true,      false,      true },
+    { "masternodelist",         &masternodelist,         true,      false,      false },
     { "keepass",                &keepass,                false,     false,      true },
 
 #ifdef ENABLE_WALLET

--- a/src/rpcserver.h
+++ b/src/rpcserver.h
@@ -198,6 +198,7 @@ extern json_spirit::Value keepass(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value darksend(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value spork(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value masternode(const json_spirit::Array& params, bool fHelp);
+extern json_spirit::Value masternodelist(const json_spirit::Array& params, bool fHelp)
 
 extern json_spirit::Value listaddressbook(const json_spirit::Array& params, bool fHelp);
 extern json_spirit::Value addressbookadd(const json_spirit::Array& params, bool fHelp);


### PR DESCRIPTION
Originally this was meant to be just some functions to save masternodes to masternode db file (masternodes.dat) but now it's extended a bit:

CMasternodeMan - masternode manager
separate messages processing
relay only enabled MN or when it's "stop"
CMasternodeDB - serializing masternodes to masternodes.dat file
flush MNs to file every MASTERNODES_DUMP_SECONDS and on shutdown
request full mn list by dseg on start only if update is required because of timeout
rename CMasterNode to CMasternode
clean out unused functions from masternode.cpp/.h
move ProcessMasternodeConnections to CDarkSendPool
-----not anymore--> check MNs and remove inactive every minute after (MASTERNODE_MIN_DSEEP_SECONDS + MASTERNODE_PING_WAIT_SECONDS) or if update is required because of timeout <------not anymore---
rpc
make "masternode list" separate command (backward compatible)
add "full" mode to "masternode list"
add filtering to "masternode list"
"count" can show enabled only