### PR TITLE
Make GetAvailableCredit run GetHash() only once per transaction

### DIFF
--- a/src/wallet.h
+++ b/src/wallet.h
@@ -371,12 +371,16 @@ public:
     int64_t GetCredit(const CTransaction& tx) const
     {
         int64_t nCredit = 0;
+        uint256 hashTx = GetHash();
         BOOST_FOREACH(const CTxOut& txout, tx.vout)
+        {
+        if (!pwallet->IsSpent(hashTx, i))
         {
             nCredit += GetCredit(txout);
             if (!MoneyRange(nCredit))
                 throw std::runtime_error("CWallet::GetCredit() : value out of range");
         }
+    }
         return nCredit;
     }
     int64_t GetChange(const CTransaction& tx) const

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -371,16 +371,12 @@ public:
     int64_t GetCredit(const CTransaction& tx) const
     {
         int64_t nCredit = 0;
-        uint256 hashTx = GetHash();
         BOOST_FOREACH(const CTxOut& txout, tx.vout)
-        {
-        if (!pwallet->IsSpent(hashTx, i))
         {
             nCredit += GetCredit(txout);
             if (!MoneyRange(nCredit))
                 throw std::runtime_error("CWallet::GetCredit() : value out of range");
         }
-    }
         return nCredit;
     }
     int64_t GetChange(const CTransaction& tx) const
@@ -734,9 +730,10 @@ public:
             return nAvailableCreditCached;
 
         int64_t nCredit = 0;
+        uint256 hashTx = GetHash();
         for (unsigned int i = 0; i < vout.size(); i++)
         {
-            if (!IsSpent(i))
+            if (!IsSpent(hashTx, i))
             {
                 const CTxOut &txout = vout[i];
                 nCredit += pwallet->GetCredit(txout);


### PR DESCRIPTION
makes the first getbalance/getinfo 63x faster on my wallet.