### PR TITLE
V3.4.0.0 dev sync

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -162,7 +162,7 @@ public:
 static CTestNetParams testNetParams;
 
 
-static CChainParams *pCurrentParams = 0;
+static CChainParams *pCurrentParams = &mainParams;
 
 const CChainParams &Params() {
     assert(pCurrentParams);

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -1213,6 +1213,67 @@ bool static CheckMinimalPush(const valtype& data, opcodetype opcode) {
     return true;
 }
 
+uint256 SignatureHash(const CScript scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType)
+{
+    if (nIn >= txTo.vin.size())
+    {
+        LogPrintf("ERROR: SignatureHash() : nIn=%d out of range\n", nIn);
+        return 1;
+    }
+    CTransaction txTmp(txTo);
+
+    // In case concatenating two scripts ends up with two codeseparators,
+    // or an extra one at the end, this prevents all those possible incompatibilities.
+    scriptCode.FindAndDelete(CScript(OP_CODESEPARATOR));
+
+    // Blank out other inputs' signatures
+    for (unsigned int i = 0; i < txTmp.vin.size(); i++)
+        txTmp.vin[i].scriptSig = CScript();
+    txTmp.vin[nIn].scriptSig = scriptCode;
+
+    // Blank out some of the outputs
+    if ((nHashType & 0x1f) == SIGHASH_NONE)
+    {
+        // Wildcard payee
+        txTmp.vout.clear();
+
+        // Let the others update at will
+        for (unsigned int i = 0; i < txTmp.vin.size(); i++)
+            if (i != nIn)
+                txTmp.vin[i].nSequence = 0;
+    }
+    else if ((nHashType & 0x1f) == SIGHASH_SINGLE)
+    {
+        // Only lock-in the txout payee at same index as txin
+        unsigned int nOut = nIn;
+        if (nOut >= txTmp.vout.size())
+        {
+            LogPrintf("ERROR: SignatureHash() : nOut=%d out of range\n", nOut);
+            return 1;
+        }
+        txTmp.vout.resize(nOut+1);
+        for (unsigned int i = 0; i < nOut; i++)
+            txTmp.vout[i].SetNull();
+
+        // Let the others update at will
+        for (unsigned int i = 0; i < txTmp.vin.size(); i++)
+            if (i != nIn)
+                txTmp.vin[i].nSequence = 0;
+    }
+
+    // Blank out other inputs completely, not recommended for open transactions
+    if (nHashType & SIGHASH_ANYONECANPAY)
+    {
+        txTmp.vin[0] = txTmp.vin[nIn];
+        txTmp.vin.resize(1);
+    }
+
+    // Serialize and hash
+    CHashWriter ss(SER_GETHASH, 0);
+    ss << txTmp << nHashType;
+    return ss.GetHash();
+}
+
 
 bool SignSignature(const CKeyStore &keystore, const CScript& fromPubKey, CMutableTransaction& txTo, unsigned int nIn, int nHashType)
 {
@@ -1791,112 +1852,21 @@ bool ExtractDestinations(const CScript& scriptPubKey, txnouttype& typeRet, vecto
     return true;
 }
 
-namespace {
-    /** Wrapper that serializes like CTransaction, but with the modifications
-     *  required for the signature hash done in-place
-     */
-    class CTransactionSignatureSerializer {
-    private:
-        const CTransaction &txTo;  // reference to the spending transaction (the one being serialized)
-        const CScript &scriptCode; // output script being consumed
-        const unsigned int nIn;    // input index of txTo being signed
-        const bool fAnyoneCanPay;  // whether the hashtype has the SIGHASH_ANYONECANPAY flag set
-        const bool fHashSingle;    // whether the hashtype is SIGHASH_SINGLE
-        const bool fHashNone;      // whether the hashtype is SIGHASH_NONE
-
-    public:
-        CTransactionSignatureSerializer(const CTransaction &txToIn, const CScript &scriptCodeIn, unsigned int nInIn, int nHashTypeIn) :
-            txTo(txToIn), scriptCode(scriptCodeIn), nIn(nInIn),
-            fAnyoneCanPay(!!(nHashTypeIn & SIGHASH_ANYONECANPAY)),
-            fHashSingle((nHashTypeIn & 0x1f) == SIGHASH_SINGLE),
-            fHashNone((nHashTypeIn & 0x1f) == SIGHASH_NONE) {}
-
-        /** Serialize the passed scriptCode, skipping OP_CODESEPARATORs */
-        template<typename S>
-        void SerializeScriptCode(S &s, int nType, int nVersion) const {
-            CScript::const_iterator it = scriptCode.begin();
-            CScript::const_iterator itBegin = it;
-            opcodetype opcode;
-            unsigned int nCodeSeparators = 0;
-            while (scriptCode.GetOp(it, opcode)) {
-                if (opcode == OP_CODESEPARATOR)
-                    nCodeSeparators++;
-            }
-            ::WriteCompactSize(s, scriptCode.size() - nCodeSeparators);
-            it = itBegin;
-            while (scriptCode.GetOp(it, opcode)) {
-                if (opcode == OP_CODESEPARATOR) {
-                    s.write((char*)&itBegin[0], it - itBegin - 1);
-                    itBegin = it;
-                }
-            }
-            s.write((char*)&itBegin[0], it - itBegin);
-        }
-        /** Serialize an input of txTo */
-        template<typename S>
-        void SerializeInput(S &s, unsigned int nInput, int nType, int nVersion) const {
-            // In case of SIGHASH_ANYONECANPAY, only the input being signed is serialized
-            if (fAnyoneCanPay)
-                nInput = nIn;
-            // Serialize the prevout
-            ::Serialize(s, txTo.vin[nInput].prevout, nType, nVersion);
-            // Serialize the script
-            if (nInput != nIn)
-                // Blank out other inputs' signatures
-                ::Serialize(s, CScript(), nType, nVersion);
-            else
-                SerializeScriptCode(s, nType, nVersion);
-            // Serialize the nSequence
-            if (nInput != nIn && (fHashSingle || fHashNone))
-                // let the others update at will
-                ::Serialize(s, (int)0, nType, nVersion);
-            else
-                ::Serialize(s, txTo.vin[nInput].nSequence, nType, nVersion);
-        }
-        /** Serialize an output of txTo */
-        template<typename S>
-        void SerializeOutput(S &s, unsigned int nOutput, int nType, int nVersion) const {
-            if (fHashSingle && nOutput != nIn)
-                // Do not lock-in the txout payee at other indices as txin
-                ::Serialize(s, CTxOut(), nType, nVersion);
-            else
-                ::Serialize(s, txTo.vout[nOutput], nType, nVersion);
-        }
-        /** Serialize txTo */
-        template<typename S>
-        void Serialize(S &s, int nType, int nVersion) const {
-            // Serialize nVersion
-            ::Serialize(s, txTo.nVersion, nType, nVersion);
-            // Serialize vin
-            unsigned int nInputs = fAnyoneCanPay ? 1 : txTo.vin.size();
-            ::WriteCompactSize(s, nInputs);
-            for (unsigned int nInput = 0; nInput < nInputs; nInput++)
-                SerializeInput(s, nInput, nType, nVersion);
-            // Serialize vout
-            unsigned int nOutputs = fHashNone ? 0 : (fHashSingle ? nIn + 1 : txTo.vout.size());
-            ::WriteCompactSize(s, nOutputs);
-            for (unsigned int nOutput = 0; nOutput < nOutputs; nOutput++)
-                SerializeOutput(s, nOutput, nType, nVersion);
-            // Serialie nLockTime
-            ::Serialize(s, txTo.nLockTime, nType, nVersion);
-        }
-    };
-} // anon namespace
-
-uint256 SignatureHash(const CScript &scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType)
+/*uint256 SignatureHash(const CScript& scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType)
 {
     if (nIn >= txTo.vin.size()) {
-        LogPrintf("ERROR: SignatureHash() : nIn=%d out of range\n", nIn);
+        //  nIn out of range
         return 1;
     }
 
     // Check for invalid use of SIGHASH_SINGLE
     if ((nHashType & 0x1f) == SIGHASH_SINGLE) {
         if (nIn >= txTo.vout.size()) {
-            LogPrintf("ERROR: SignatureHash() : nOut=%d out of range\n", nIn);
+            //  nOut out of range
             return 1;
         }
     }
+
     // Wrapper to serialize only the necessary parts of the transaction being signed
     CTransactionSignatureSerializer txTmp(txTo, scriptCode, nIn, nHashType);
 
@@ -1904,7 +1874,7 @@ uint256 SignatureHash(const CScript &scriptCode, const CTransaction& txTo, unsig
     CHashWriter ss(SER_GETHASH, 0);
     ss << txTmp << nHashType;
     return ss.GetHash();
-}
+}*/
 
 bool SignatureChecker::VerifySignature(const std::vector<unsigned char>& vchSig, const CPubKey& pubkey, const uint256& sighash) const
 {

--- a/src/script.cpp
+++ b/src/script.cpp
@@ -1213,7 +1213,12 @@ bool static CheckMinimalPush(const valtype& data, opcodetype opcode) {
     return true;
 }
 
-uint256 SignatureHash(const CScript scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType)
+
+
+
+
+
+uint256 SignatureHash(CScript scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType)
 {
     if (nIn >= txTo.vin.size())
     {

--- a/src/script.h
+++ b/src/script.h
@@ -905,7 +905,6 @@ public:
 
 bool IsDERSignature(const valtype &vchSig, bool haveHashType = true);
 bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& script, const CTransaction& txTo, unsigned int nIn, unsigned int flags, int nHashType);
-uint256 SignatureHash(const CScript &scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType);
 bool Solver(const CScript& scriptPubKey, txnouttype& typeRet, std::vector<std::vector<unsigned char> >& vSolutionsRet);
 int ScriptSigArgsExpected(txnouttype t, const std::vector<std::vector<unsigned char> >& vSolutions);
 bool IsStandard(const CScript& scriptPubKey, txnouttype& whichType);

--- a/src/script.h
+++ b/src/script.h
@@ -927,6 +927,7 @@ CScript GetScriptForMultisig(int nRequired, const std::vector<CPubKey>& keys);
 
 bool Solver(const CKeyStore& keystore, const CScript& scriptPubKey, uint256 hash, int nHashType,
                   CScript& scriptSigRet, txnouttype& whichTypeRet);
+//uint256 SignatureHash(const CScript &scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType);
 
 
 class BaseSignatureChecker

--- a/src/util.h
+++ b/src/util.h
@@ -457,6 +457,12 @@ public:
 void SetThreadPriority(int nPriority);
 void RenameThread(const char* name);
 
+inline uint32_t ByteReverse(uint32_t value)
+{
+    value = ((value & 0xFF00FF00) >> 8) | ((value & 0x00FF00FF) << 8);
+    return (value<<16) | (value>>16);
+}
+
 // Standard wrapper for do-something-forever thread functions.
 // "Forever" really means until the thread is interrupted.
 // Use it like:


### PR DESCRIPTION
A few reverts and a fix.
The fix ensures that the MAIN chain is selected by default and passes the assert() in chainparams.cpp, No idea why setting this to 0 like every other coin causes segfault, but for now this fix get it working again.

The revert fix failures to sync past the first 100 PoW blocks. Fairly sure that the Signature Serialiser doesn't like our PoS, so need to do some more digging when verifying sigs and using this.