### PR TITLE
Stake spliting fixes

### DIFF
--- a/.github/workflows/cpp-linter.yml
+++ b/.github/workflows/cpp-linter.yml
@@ -10,7 +10,7 @@ jobs:
   cpp-linter:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       - uses: cpp-linter/cpp-linter-action@v2
         id: linter
         env:

--- a/.github/workflows/cpp-make.yml
+++ b/.github/workflows/cpp-make.yml
@@ -8,9 +8,9 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
       # sync repo modules
       - name: Pull & update submodules recursively
         run: git submodule update --init --recursive

--- a/configure.ac
+++ b/configure.ac
@@ -1349,7 +1349,7 @@ fi
 # These packages don't provide pkgconfig config files across all
 # platforms, so we use older autoconf detection mechanisms:
 AC_CHECK_HEADER([gmp.h],,AC_MSG_ERROR(libgmp headers missing))
-AC_CHECK_LIB([gmp],[[mpn_sub_n]],GMP_LIBS=-lgmp, [AC_MSG_ERROR(libgmp missing)])
+AC_CHECK_LIB([gmp],[__gmpn_sub_n],GMP_LIBS=-lgmp, [AC_MSG_ERROR(libgmp missing)])
 
 AC_CHECK_HEADER([gmpxx.h],,AC_MSG_ERROR(libgmpxx headers missing))
 AC_CHECK_LIB([gmpxx],[main],GMPXX_LIBS=-lgmpxx, [AC_MSG_ERROR(libgmpxx missing)])

--- a/configure.ac
+++ b/configure.ac
@@ -1349,7 +1349,7 @@ fi
 # These packages don't provide pkgconfig config files across all
 # platforms, so we use older autoconf detection mechanisms:
 AC_CHECK_HEADER([gmp.h],,AC_MSG_ERROR(libgmp headers missing))
-AC_CHECK_LIB([gmp],[[__gmpn_sub_n]],GMP_LIBS=-lgmp, [AC_MSG_ERROR(libgmp missing)])
+AC_CHECK_LIB([gmp],[[mpn_sub_n]],GMP_LIBS=-lgmp, [AC_MSG_ERROR(libgmp missing)])
 
 AC_CHECK_HEADER([gmpxx.h],,AC_MSG_ERROR(libgmpxx headers missing))
 AC_CHECK_LIB([gmpxx],[main],GMPXX_LIBS=-lgmpxx, [AC_MSG_ERROR(libgmpxx missing)])

--- a/configure.ac
+++ b/configure.ac
@@ -325,6 +325,26 @@ fi
 
 CPPFLAGS="$CPPFLAGS -DQTUM_BUILD"
 
+# Newer Boost (>=1.69) has its own std::hash<boost::asio::ip::address> specialization,
+# which collides with the one vendored in src/cpp-ethereum/libp2p/Common.h. Rather than
+# patch the cpp-ethereum submodule, tell Boost.Asio to skip its own via its documented
+# opt-out macro, leaving the submodule's copy as the sole definition.
+CPPFLAGS="$CPPFLAGS -DBOOST_ASIO_DISABLE_STD_HASH"
+
+# Newer Boost (>=1.74 or so) turns <boost/timer.hpp> into a hard #error since it's
+# deprecated. cpp-ethereum/libethereum/Executive.cpp still includes it; rather than
+# patch the submodule, use Boost's own documented opt-out to keep the deprecated
+# header usable.
+CPPFLAGS="$CPPFLAGS -DBOOST_TIMER_ENABLE_DEPRECATED"
+
+# Boost >= 1.73 dropped the internal helper boost::exception_detail::throw_exception_,
+# which src/cpp-ethereum/libdevcore/Common.cpp calls directly by its fully qualified
+# name. There is no documented Boost opt-out for this one (it's a removed internal
+# symbol, not a deprecation flag), so restore it via a force-included compat shim
+# (src/qtum/boost_compat.h) instead of patching the submodule. See that file for
+# details; revisit patching cpp-eth-metrix upstream if this becomes hard to carry.
+CPPFLAGS="$CPPFLAGS -include $(cd "$srcdir" && pwd)/src/qtum/boost_compat.h"
+
 ERROR_CXXFLAGS=
 if test "x$enable_werror" = "xyes"; then
   if test "x$CXXFLAG_WERROR" = "x"; then

--- a/src/pos.cpp
+++ b/src/pos.cpp
@@ -310,8 +310,6 @@ int64_t GetStakeCombineThreshold() { return 500000 * COIN; }
 
 unsigned int GetStakeSplitOutputs() { return 2; }
 
-int64_t GetStakeSplitThreshold() { return GetStakeSplitOutputs() * GetStakeCombineThreshold(); }
-
 bool NeedToEraseScriptFromCache(int nBlockHeight, int nCacheScripts, int nScriptHeight, const ScriptsElement& scriptElement)
 {
     // Erase element from cache if not in range [nBlockHeight - nCacheScripts, nBlockHeight + nCacheScripts]

--- a/src/pos.cpp
+++ b/src/pos.cpp
@@ -306,8 +306,6 @@ std::map<int, ScriptsElement> scriptsMap;
 
 unsigned int GetStakeMaxCombineInputs() { return 100; }
 
-int64_t GetStakeCombineThreshold() { return 500000 * COIN; }
-
 unsigned int GetStakeSplitOutputs() { return 2; }
 
 bool NeedToEraseScriptFromCache(int nBlockHeight, int nCacheScripts, int nScriptHeight, const ScriptsElement& scriptElement)

--- a/src/pos.h
+++ b/src/pos.h
@@ -58,8 +58,6 @@ bool CheckKernel(CBlockIndex* pindexPrev, unsigned int nBits, uint32_t nTimeBloc
 
 unsigned int GetStakeMaxCombineInputs();
 
-int64_t GetStakeCombineThreshold();
-
 unsigned int GetStakeSplitOutputs();
 
 bool GetMPoSOutputs(std::vector<CTxOut>& mposOutputList, int64_t nRewardPiece, int nHeight, const Consensus::Params& consensusParams);

--- a/src/pos.h
+++ b/src/pos.h
@@ -62,8 +62,6 @@ int64_t GetStakeCombineThreshold();
 
 unsigned int GetStakeSplitOutputs();
 
-int64_t GetStakeSplitThreshold();
-
 bool GetMPoSOutputs(std::vector<CTxOut>& mposOutputList, int64_t nRewardPiece, int nHeight, const Consensus::Params& consensusParams);
 
 bool CreateMPoSOutputs(CMutableTransaction& txNew, int64_t nRewardPiece, int nHeight, const Consensus::Params& consensusParams);

--- a/src/qtum/boost_compat.h
+++ b/src/qtum/boost_compat.h
@@ -1,0 +1,54 @@
+// Compatibility shims for building the vendored src/cpp-ethereum submodule against
+// modern Boost, without patching the submodule itself. Force-included ahead of every
+// translation unit via -include in configure.ac. Grows as new Boost/submodule
+// incompatibilities turn up; each fix documents what it's working around.
+#pragma once
+
+// Force-included via -include into every translation unit (see configure.ac), C and
+// C++ alike, so this must be a no-op for C (plain #define flags are safe there, but
+// namespaces/templates/Boost headers are not).
+#if defined(__cplusplus)
+
+#include <boost/version.hpp>
+
+// Boost's BOOST_THROW_EXCEPTION macro used to expand to a call to the internal
+// helper boost::exception_detail::throw_exception_(x, current_function, file, line).
+// Since Boost 1.73 (confirmed present in 1.72.0, gone in 1.73.0) that helper was
+// removed in favor of boost::throw_exception(x, source_location) with the macro
+// calling that new form directly instead.
+//
+// src/cpp-ethereum/libdevcore/Common.cpp calls the old internal helper by its fully
+// qualified name directly (not via the macro), so it fails to compile against any
+// Boost new enough to have dropped it. This restores that old helper with its
+// original implementation (see Boost 1.72.0's boost/throw_exception.hpp).
+#if BOOST_VERSION >= 107300
+#include <boost/exception/exception.hpp>
+#include <boost/exception/info.hpp>
+#include <boost/throw_exception.hpp>
+
+namespace boost { namespace exception_detail {
+
+template <class E>
+BOOST_NORETURN inline void
+throw_exception_(E const& x, char const* current_function, char const* file, int line)
+{
+    boost::throw_exception(
+        boost::enable_error_info(x) <<
+        boost::throw_function(current_function) <<
+        boost::throw_file(file) <<
+        boost::throw_line(line));
+}
+
+}} // namespace boost::exception_detail
+#endif // BOOST_VERSION >= 107300
+
+// boost::filesystem::ifstream/ofstream (thin wrappers over std::ifstream/ofstream
+// that accept a boost::filesystem::path directly) live in
+// <boost/filesystem/fstream.hpp>, which used to be pulled in by the <boost/filesystem.hpp>
+// umbrella header but no longer is on newer Boost (confirmed missing from the
+// umbrella on Boost 1.83). src/cpp-ethereum/libdevcore/CommonIO.cpp only includes
+// the umbrella header but uses boost::filesystem::ifstream/ofstream, so pull the
+// dedicated header in here. The classes themselves still exist unchanged.
+#include <boost/filesystem/fstream.hpp>
+
+#endif // defined(__cplusplus)

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -208,6 +208,7 @@ static const CRPCConvertParam vRPCConvertParams[] = {
     { "reservebalance", 0, "reserve"},
     { "reservebalance", 1, "amount"},
     { "setstakesplitthreshold", 0, "threshold"},
+    { "setstakecombinethreshold", 0, "threshold"},
     { "listcontracts", 0, "start" },
     { "listcontracts", 1, "maxDisplay" },
     { "listallcontracts", 0, "height" },

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -207,6 +207,7 @@ static const CRPCConvertParam vRPCConvertParams[] = {
     { "callcontract", 4, "blockNum" },
     { "reservebalance", 0, "reserve"},
     { "reservebalance", 1, "amount"},
+    { "setstakesplitthreshold", 0, "threshold"},
     { "listcontracts", 0, "start" },
     { "listcontracts", 1, "maxDisplay" },
     { "listallcontracts", 0, "height" },

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1425,6 +1425,16 @@ uint256 SignatureHash(const CScript& scriptCode, const T& txTo, unsigned int nIn
     return ss.GetHash();
 }
 
+// explicit instantiation
+// SignatureHash and SignatureHashOutput are only otherwise reached indirectly, via the
+// (explicitly instantiated) *Checker classes below calling them; relying on that
+// cascade to also instantiate these free functions is fragile across compilers, so
+// instantiate them directly too.
+template uint256 SignatureHashOutput(const CScript& scriptCode, const CTransaction& txTo, unsigned int nOut, int nHashType, const CAmount& amount, SigVersion sigversion, const PrecomputedTransactionData* cache);
+template uint256 SignatureHashOutput(const CScript& scriptCode, const CMutableTransaction& txTo, unsigned int nOut, int nHashType, const CAmount& amount, SigVersion sigversion, const PrecomputedTransactionData* cache);
+template uint256 SignatureHash(const CScript& scriptCode, const CTransaction& txTo, unsigned int nIn, int nHashType, const CAmount& amount, SigVersion sigversion, const PrecomputedTransactionData* cache);
+template uint256 SignatureHash(const CScript& scriptCode, const CMutableTransaction& txTo, unsigned int nIn, int nHashType, const CAmount& amount, SigVersion sigversion, const PrecomputedTransactionData* cache);
+
 template <class T>
 bool GenericTransactionSignatureChecker<T>::VerifySignature(const std::vector<unsigned char>& vchSig, const CPubKey& pubkey, const uint256& sighash) const
 {

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -69,6 +69,7 @@ void WalletInit::AddWalletOptions() const
     gArgs.AddArg("-stakecache=<true/false>", "Enables or disables the staking cache; significantly improves staking performance, but can use a lot of memory (enabled by default)", ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
     gArgs.AddArg("-rpcmaxgasprice", strprintf("The max value (in satoshis) for gas price allowed through RPC (default: %u)", MAX_RPC_GAS_PRICE), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
     gArgs.AddArg("-reservebalance", strprintf("Reserved balance not used for staking (default: %u)", DEFAULT_RESERVE_BALANCE), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
+    gArgs.AddArg("-stakesplitthreshold", strprintf("Staking outputs above this threshold will be split into two outputs (default: %u)", DEFAULT_STAKE_SPLIT_THRESHOLD), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
     gArgs.AddArg("-usechangeaddress", strprintf("Use change address (default: %u)", DEFAULT_USE_CHANGE_ADDRESS), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
     gArgs.AddArg("-dblogsize=<n>", strprintf("Flush wallet database activity from memory to disk log every <n> megabytes (default: %u)", DEFAULT_WALLET_DBLOGSIZE), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::WALLET_DEBUG_TEST);
     gArgs.AddArg("-flushwallet", strprintf("Run a thread to flush wallet periodically (default: %u)", DEFAULT_FLUSHWALLET), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::WALLET_DEBUG_TEST);

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -70,6 +70,7 @@ void WalletInit::AddWalletOptions() const
     gArgs.AddArg("-rpcmaxgasprice", strprintf("The max value (in satoshis) for gas price allowed through RPC (default: %u)", MAX_RPC_GAS_PRICE), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
     gArgs.AddArg("-reservebalance", strprintf("Reserved balance not used for staking (default: %u)", DEFAULT_RESERVE_BALANCE), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
     gArgs.AddArg("-stakesplitthreshold", strprintf("Staking outputs above this threshold will be split into two outputs (default: %u)", DEFAULT_STAKE_SPLIT_THRESHOLD), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
+    gArgs.AddArg("-stakecombinethreshold", strprintf("Additional inputs below this threshold will be combined into a coinstake (default: %u)", DEFAULT_STAKE_COMBINE_THRESHOLD), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
     gArgs.AddArg("-usechangeaddress", strprintf("Use change address (default: %u)", DEFAULT_USE_CHANGE_ADDRESS), ArgsManager::ALLOW_ANY, OptionsCategory::WALLET);
     gArgs.AddArg("-dblogsize=<n>", strprintf("Flush wallet database activity from memory to disk log every <n> megabytes (default: %u)", DEFAULT_WALLET_DBLOGSIZE), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::WALLET_DEBUG_TEST);
     gArgs.AddArg("-flushwallet", strprintf("Run a thread to flush wallet periodically (default: %u)", DEFAULT_FLUSHWALLET), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::WALLET_DEBUG_TEST);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3093,6 +3093,54 @@ static UniValue setstakesplitthreshold(const JSONRPCRequest& request)
     return result;
 }
 
+static UniValue setstakecombinethreshold(const JSONRPCRequest& request)
+{
+    std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
+    CWallet* const pwallet = wallet.get();
+
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp)) {
+        return NullUniValue;
+    }
+
+            RPCHelpMan{"setstakecombinethreshold",
+            "\nSet the threshold below which additional inputs will be combined into a coinstake."
+            "\nLowering this on wallets with a very large number of small inputs (e.g. on testnet) can"
+            "\nreduce how many inputs get pulled into a single coinstake and help avoid it hanging."
+            "\nIf no parameter is provided the current setting is printed.\n",
+            {
+                {"threshold", RPCArg::Type::AMOUNT, RPCArg::Optional::OMITTED, "the new threshold, in " + CURRENCY_UNIT + "."},
+            },
+            RPCResult{
+                       "{\n"
+                       "  \"threshold\": xxxx,        (numeric) The new threshold in " + CURRENCY_UNIT + "\n"
+                       "  \"saved\": true|false       (boolean) 'true' if setting was saved to the wallet, 'false' otherwise\n"
+                       "}\n"
+                   },
+             RPCExamples{
+            "\nSet the threshold to 100\n"
+            + HelpExampleCli("setstakecombinethreshold", "100") +
+            "\nGet the current threshold\n"
+            + HelpExampleCli("setstakecombinethreshold", "")			},
+            }.Check(request);
+
+    UniValue result(UniValue::VOBJ);
+
+    if (request.params.size() > 0)
+    {
+        CAmount nStakeCombineThreshold = AmountFromValue(request.params[0]);
+        if (nStakeCombineThreshold < 0)
+            throw std::runtime_error("threshold cannot be negative.\n");
+
+        LOCK(pwallet->cs_wallet);
+        pwallet->nStakeCombineThreshold = nStakeCombineThreshold;
+        WalletBatch batch(pwallet->GetDBHandle());
+        result.pushKV("saved", batch.WriteStakeCombineThreshold(nStakeCombineThreshold));
+    }
+
+    result.pushKV("threshold", ValueFromAmount(pwallet->nStakeCombineThreshold));
+    return result;
+}
+
 static UniValue lockunspent(const JSONRPCRequest& request)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
@@ -3409,6 +3457,7 @@ static UniValue getwalletinfo(const JSONRPCRequest& request)
             "  \"encryption_status\": ttt,          (string) the encryption status of the wallet\n"
             "  \"paytxfee\": x.xxxx,                (numeric) the transaction fee configuration, set in " + CURRENCY_UNIT + "/kB\n"
             "  \"stakesplitthreshold\": x.xxxx,     (numeric) the threshold above which staking outputs will be split, set in " + CURRENCY_UNIT + "\n"
+            "  \"stakecombinethreshold\": x.xxxx,   (numeric) the threshold below which additional inputs will be combined into a coinstake, set in " + CURRENCY_UNIT + "\n"
             "  \"hdseedid\": \"<hash160>\"          (string, optional) the Hash160 of the HD seed (only present when HD is enabled)\n"
             "  \"private_keys_enabled\": true|false (boolean) false if privatekeys are disabled for this wallet (enforced watch-only wallet)\n"
             "  \"avoid_reuse\": true|false          (boolean) whether this wallet tracks clean/dirty coins in terms of reuse\n"
@@ -3476,6 +3525,7 @@ static UniValue getwalletinfo(const JSONRPCRequest& request)
     }
     obj.pushKV("paytxfee", ValueFromAmount(pwallet->m_pay_tx_fee.GetFeePerK()));
     obj.pushKV("stakesplitthreshold", ValueFromAmount(pwallet->nStakeSplitThreshold));
+    obj.pushKV("stakecombinethreshold", ValueFromAmount(pwallet->nStakeCombineThreshold));
     obj.pushKV("private_keys_enabled", !pwallet->IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS));
     obj.pushKV("avoid_reuse", pwallet->IsWalletFlagSet(WALLET_FLAG_AVOID_REUSE));
     if (pwallet->IsScanning()) {
@@ -5413,6 +5463,7 @@ static const CRPCCommand commands[] =
     { "wallet",             "sendtoaddress",                    &sendtoaddress,                 {"address","amount","comment","comment_to","subtractfeefromamount","replaceable","conf_target","estimate_mode","avoid_reuse","senderAddress","changeToSender"} },
     { "wallet",             "sethdseed",                        &sethdseed,                     {"newkeypool","seed"} },
     { "wallet",             "setlabel",                         &setlabel,                      {"address","label"} },
+    { "wallet",             "setstakecombinethreshold",         &setstakecombinethreshold,      {"threshold"} },
     { "wallet",             "setstakesplitthreshold",           &setstakesplitthreshold,        {"threshold"} },
     { "wallet",             "settxfee",                         &settxfee,                      {"amount"} },
     { "wallet",             "setwalletflag",                    &setwalletflag,                 {"flag","value"} },

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3047,6 +3047,52 @@ static UniValue reservebalance(const JSONRPCRequest& request)
     return result;
 }
 
+static UniValue setstakesplitthreshold(const JSONRPCRequest& request)
+{
+    std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
+    CWallet* const pwallet = wallet.get();
+
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp)) {
+        return NullUniValue;
+    }
+
+            RPCHelpMan{"setstakesplitthreshold",
+            "\nSet the threshold above which staking outputs will be split into two outputs."
+            "\nIf no parameter is provided the current setting is printed.\n",
+            {
+                {"threshold", RPCArg::Type::AMOUNT, RPCArg::Optional::OMITTED, "the new threshold, in " + CURRENCY_UNIT + "."},
+            },
+            RPCResult{
+                       "{\n"
+                       "  \"threshold\": xxxx,        (numeric) The new threshold in " + CURRENCY_UNIT + "\n"
+                       "  \"saved\": true|false       (boolean) 'true' if setting was saved to the wallet, 'false' otherwise\n"
+                       "}\n"
+                   },
+             RPCExamples{
+            "\nSet the threshold to 100\n"
+            + HelpExampleCli("setstakesplitthreshold", "100") +
+            "\nGet the current threshold\n"
+            + HelpExampleCli("setstakesplitthreshold", "")			},
+            }.Check(request);
+
+    UniValue result(UniValue::VOBJ);
+
+    if (request.params.size() > 0)
+    {
+        CAmount nStakeSplitThreshold = AmountFromValue(request.params[0]);
+        if (nStakeSplitThreshold < 0)
+            throw std::runtime_error("threshold cannot be negative.\n");
+
+        LOCK(pwallet->cs_wallet);
+        pwallet->nStakeSplitThreshold = nStakeSplitThreshold;
+        WalletBatch batch(pwallet->GetDBHandle());
+        result.pushKV("saved", batch.WriteStakeSplitThreshold(nStakeSplitThreshold));
+    }
+
+    result.pushKV("threshold", ValueFromAmount(pwallet->nStakeSplitThreshold));
+    return result;
+}
+
 static UniValue lockunspent(const JSONRPCRequest& request)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
@@ -3362,6 +3408,7 @@ static UniValue getwalletinfo(const JSONRPCRequest& request)
             "  \"unlocked_until\": ttt,             (numeric) the timestamp in seconds since epoch (midnight Jan 1 1970 GMT) that the wallet is unlocked for transfers, or 0 if the wallet is locked\n"
             "  \"encryption_status\": ttt,          (string) the encryption status of the wallet\n"
             "  \"paytxfee\": x.xxxx,                (numeric) the transaction fee configuration, set in " + CURRENCY_UNIT + "/kB\n"
+            "  \"stakesplitthreshold\": x.xxxx,     (numeric) the threshold above which staking outputs will be split, set in " + CURRENCY_UNIT + "\n"
             "  \"hdseedid\": \"<hash160>\"          (string, optional) the Hash160 of the HD seed (only present when HD is enabled)\n"
             "  \"private_keys_enabled\": true|false (boolean) false if privatekeys are disabled for this wallet (enforced watch-only wallet)\n"
             "  \"avoid_reuse\": true|false          (boolean) whether this wallet tracks clean/dirty coins in terms of reuse\n"
@@ -3428,6 +3475,7 @@ static UniValue getwalletinfo(const JSONRPCRequest& request)
         obj.pushKV("encryption_status", "Unencrypted");
     }
     obj.pushKV("paytxfee", ValueFromAmount(pwallet->m_pay_tx_fee.GetFeePerK()));
+    obj.pushKV("stakesplitthreshold", ValueFromAmount(pwallet->nStakeSplitThreshold));
     obj.pushKV("private_keys_enabled", !pwallet->IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS));
     obj.pushKV("avoid_reuse", pwallet->IsWalletFlagSet(WALLET_FLAG_AVOID_REUSE));
     if (pwallet->IsScanning()) {
@@ -5365,6 +5413,7 @@ static const CRPCCommand commands[] =
     { "wallet",             "sendtoaddress",                    &sendtoaddress,                 {"address","amount","comment","comment_to","subtractfeefromamount","replaceable","conf_target","estimate_mode","avoid_reuse","senderAddress","changeToSender"} },
     { "wallet",             "sethdseed",                        &sethdseed,                     {"newkeypool","seed"} },
     { "wallet",             "setlabel",                         &setlabel,                      {"address","label"} },
+    { "wallet",             "setstakesplitthreshold",           &setstakesplitthreshold,        {"threshold"} },
     { "wallet",             "settxfee",                         &settxfee,                      {"amount"} },
     { "wallet",             "setwalletflag",                    &setwalletflag,                 {"flag","value"} },
     { "wallet",             "signmessage",                      &signmessage,                   {"address","message"} },

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3304,7 +3304,7 @@ bool CWallet::CreateCoinStake(interfaces::Chain::Lock& locked_chain, const Filla
         }
    }
 
-    if (nCredit >= GetStakeSplitThreshold())
+    if (nCredit >= nStakeSplitThreshold)
     {
         for(unsigned int i = 0; i < GetStakeSplitOutputs() - 1; i++)
             txNew.vout.push_back(CTxOut(0, txNew.vout[1].scriptPubKey)); //split stake
@@ -4310,6 +4310,12 @@ std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(interfaces::Chain& chain,
     walletInstance->m_signal_rbf = gArgs.GetBoolArg("-walletrbf", DEFAULT_WALLET_RBF);
     if(!ParseMoney(gArgs.GetArg("-reservebalance", FormatMoney(DEFAULT_RESERVE_BALANCE)), walletInstance->m_reserve_balance))
         walletInstance->m_reserve_balance = DEFAULT_RESERVE_BALANCE;
+    if (gArgs.IsArgSet("-stakesplitthreshold")) {
+        if (!ParseMoney(gArgs.GetArg("-stakesplitthreshold", ""), walletInstance->nStakeSplitThreshold)) {
+            chain.initError(AmountErrMsg("stakesplitthreshold", gArgs.GetArg("-stakesplitthreshold", "")).translated);
+            return nullptr;
+        }
+    }
     walletInstance->m_use_change_address = gArgs.GetBoolArg("-usechangeaddress", DEFAULT_USE_CHANGE_ADDRESS);
 
     walletInstance->WalletLogPrintf("Wallet completed loading in %15dms\n", GetTimeMillis() - nStart);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3271,7 +3271,7 @@ bool CWallet::CreateCoinStake(interfaces::Chain::Lock& locked_chain, const Filla
             if (nCredit + pcoin.first->tx->vout[pcoin.second].nValue > nBalance - m_reserve_balance)
                 break;
             // Do not add additional significant input
-            if (pcoin.first->tx->vout[pcoin.second].nValue >= GetStakeCombineThreshold())
+            if (pcoin.first->tx->vout[pcoin.second].nValue >= nStakeCombineThreshold)
                 continue;
 
             txNew.vin.push_back(CTxIn(pcoin.first->GetHash(), pcoin.second));
@@ -4313,6 +4313,12 @@ std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(interfaces::Chain& chain,
     if (gArgs.IsArgSet("-stakesplitthreshold")) {
         if (!ParseMoney(gArgs.GetArg("-stakesplitthreshold", ""), walletInstance->nStakeSplitThreshold)) {
             chain.initError(AmountErrMsg("stakesplitthreshold", gArgs.GetArg("-stakesplitthreshold", "")).translated);
+            return nullptr;
+        }
+    }
+    if (gArgs.IsArgSet("-stakecombinethreshold")) {
+        if (!ParseMoney(gArgs.GetArg("-stakecombinethreshold", ""), walletInstance->nStakeCombineThreshold)) {
+            chain.initError(AmountErrMsg("stakecombinethreshold", gArgs.GetArg("-stakecombinethreshold", "")).translated);
             return nullptr;
         }
     }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -89,6 +89,8 @@ static const bool DEFAULT_USE_CHANGE_ADDRESS = true;
 static const CAmount DEFAULT_RESERVE_BALANCE = 0;
 //! Default threshold above which staking outputs will be split (in satoshis)
 static const CAmount DEFAULT_STAKE_SPLIT_THRESHOLD = 1000000 * COIN;
+//! Default threshold below which additional inputs will be combined into a coinstake (in satoshis)
+static const CAmount DEFAULT_STAKE_COMBINE_THRESHOLD = 500000 * COIN;
 //! -maxtxfee default
 constexpr CAmount DEFAULT_TRANSACTION_MAXFEE{10000 * DEFAULT_TRANSACTION_MINFEE};
 //! Discourage users to set fees higher than this amount (in satoshis) per kB
@@ -999,6 +1001,7 @@ public:
     bool m_use_change_address{DEFAULT_USE_CHANGE_ADDRESS};
     CAmount m_reserve_balance{DEFAULT_RESERVE_BALANCE};
     CAmount nStakeSplitThreshold{DEFAULT_STAKE_SPLIT_THRESHOLD};
+    CAmount nStakeCombineThreshold{DEFAULT_STAKE_COMBINE_THRESHOLD};
     int64_t m_last_coin_stake_search_time{0};
     int64_t m_last_coin_stake_search_interval{0};
     std::atomic<bool> m_enabled_staking{false};

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -87,6 +87,8 @@ static const bool DEFAULT_WALLETBROADCAST = true;
 static const bool DEFAULT_DISABLE_WALLET = false;
 static const bool DEFAULT_USE_CHANGE_ADDRESS = true;
 static const CAmount DEFAULT_RESERVE_BALANCE = 0;
+//! Default threshold above which staking outputs will be split (in satoshis)
+static const CAmount DEFAULT_STAKE_SPLIT_THRESHOLD = 1000000 * COIN;
 //! -maxtxfee default
 constexpr CAmount DEFAULT_TRANSACTION_MAXFEE{10000 * DEFAULT_TRANSACTION_MINFEE};
 //! Discourage users to set fees higher than this amount (in satoshis) per kB
@@ -996,6 +998,7 @@ public:
     std::atomic<bool> m_wallet_unlock_staking_only{false};
     bool m_use_change_address{DEFAULT_USE_CHANGE_ADDRESS};
     CAmount m_reserve_balance{DEFAULT_RESERVE_BALANCE};
+    CAmount nStakeSplitThreshold{DEFAULT_STAKE_SPLIT_THRESHOLD};
     int64_t m_last_coin_stake_search_time{0};
     int64_t m_last_coin_stake_search_interval{0};
     std::atomic<bool> m_enabled_staking{false};

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -41,6 +41,7 @@ const std::string ORDERPOSNEXT{"orderposnext"};
 const std::string POOL{"pool"};
 const std::string PURPOSE{"purpose"};
 const std::string SETTINGS{"settings"};
+const std::string STAKE_SPLIT_THRESHOLD{"stakeSplitThreshold"};
 const std::string TX{"tx"};
 const std::string VERSION{"version"};
 const std::string WATCHMETA{"watchmeta"};
@@ -162,6 +163,11 @@ bool WalletBatch::ReadBestBlock(CBlockLocator& locator)
 bool WalletBatch::WriteOrderPosNext(int64_t nOrderPosNext)
 {
     return WriteIC(DBKeys::ORDERPOSNEXT, nOrderPosNext);
+}
+
+bool WalletBatch::WriteStakeSplitThreshold(const CAmount& nStakeSplitThreshold)
+{
+    return WriteIC(DBKeys::STAKE_SPLIT_THRESHOLD, nStakeSplitThreshold);
 }
 
 bool WalletBatch::ReadPool(int64_t nPool, CKeyPool& keypool)
@@ -388,6 +394,8 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
             }
         } else if (strType == DBKeys::ORDERPOSNEXT) {
             ssValue >> pwallet->nOrderPosNext;
+        } else if (strType == DBKeys::STAKE_SPLIT_THRESHOLD) {
+            ssValue >> pwallet->nStakeSplitThreshold;
         } else if (strType == DBKeys::DESTDATA) {
             std::string strAddress, strKey, strValue;
             ssKey >> strAddress;

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -42,6 +42,7 @@ const std::string POOL{"pool"};
 const std::string PURPOSE{"purpose"};
 const std::string SETTINGS{"settings"};
 const std::string STAKE_SPLIT_THRESHOLD{"stakeSplitThreshold"};
+const std::string STAKE_COMBINE_THRESHOLD{"stakeCombineThreshold"};
 const std::string TX{"tx"};
 const std::string VERSION{"version"};
 const std::string WATCHMETA{"watchmeta"};
@@ -168,6 +169,11 @@ bool WalletBatch::WriteOrderPosNext(int64_t nOrderPosNext)
 bool WalletBatch::WriteStakeSplitThreshold(const CAmount& nStakeSplitThreshold)
 {
     return WriteIC(DBKeys::STAKE_SPLIT_THRESHOLD, nStakeSplitThreshold);
+}
+
+bool WalletBatch::WriteStakeCombineThreshold(const CAmount& nStakeCombineThreshold)
+{
+    return WriteIC(DBKeys::STAKE_COMBINE_THRESHOLD, nStakeCombineThreshold);
 }
 
 bool WalletBatch::ReadPool(int64_t nPool, CKeyPool& keypool)
@@ -396,6 +402,8 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
             ssValue >> pwallet->nOrderPosNext;
         } else if (strType == DBKeys::STAKE_SPLIT_THRESHOLD) {
             ssValue >> pwallet->nStakeSplitThreshold;
+        } else if (strType == DBKeys::STAKE_COMBINE_THRESHOLD) {
+            ssValue >> pwallet->nStakeCombineThreshold;
         } else if (strType == DBKeys::DESTDATA) {
             std::string strAddress, strKey, strValue;
             ssKey >> strAddress;

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -248,6 +248,8 @@ public:
 
     bool WriteOrderPosNext(int64_t nOrderPosNext);
 
+    bool WriteStakeSplitThreshold(const CAmount& nStakeSplitThreshold);
+
     bool ReadPool(int64_t nPool, CKeyPool& keypool);
     bool WritePool(int64_t nPool, const CKeyPool& keypool);
     bool ErasePool(int64_t nPool);

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -250,6 +250,8 @@ public:
 
     bool WriteStakeSplitThreshold(const CAmount& nStakeSplitThreshold);
 
+    bool WriteStakeCombineThreshold(const CAmount& nStakeCombineThreshold);
+
     bool ReadPool(int64_t nPool, CKeyPool& keypool);
     bool WritePool(int64_t nPool, const CKeyPool& keypool);
     bool ErasePool(int64_t nPool);


### PR DESCRIPTION
Testnet has thousands of inputs and causing the daemon to hand and run very slowly when staking. The ability to reduce the inputs should help speed it up again.