### PR TITLE
CI: trigger Test Release Builds workflow

### DIFF
--- a/.github/workflows/test-release-builds.yml
+++ b/.github/workflows/test-release-builds.yml
@@ -53,7 +53,7 @@ jobs:
           apt-get install -y --no-install-recommends \
             git ca-certificates curl \
             make automake cmake libtool binutils-gold bsdmainutils \
-            pkg-config python3 patch lbzip2 g++-multilib \
+            pkg-config python3 patch lbzip2 xz-utils g++-multilib \
             ${{ matrix.packages }}
 
       - uses: actions/checkout@v5

--- a/.github/workflows/test-release-builds.yml
+++ b/.github/workflows/test-release-builds.yml
@@ -38,7 +38,10 @@ jobs:
             bin_ext: ".exe"
           - host: x86_64-apple-darwin14
             name: macos-x86_64
-            packages: "librsvg2-bin libtiff-tools imagemagick libcap-dev libz-dev libbz2-dev python3-setuptools"
+            # libtinfo5: depends' native_cctools downloads a prebuilt clang+llvm binary
+            # built for Ubuntu 18.04, which is dynamically linked against libtinfo.so.5;
+            # 20.04 (this job's container) only ships libtinfo6 by default.
+            packages: "librsvg2-bin libtiff-tools imagemagick libcap-dev libz-dev libbz2-dev python3-setuptools libtinfo5"
             bin_ext: ""
     env:
       HOST: ${{ matrix.host }}

--- a/configure.ac
+++ b/configure.ac
@@ -343,7 +343,13 @@ CPPFLAGS="$CPPFLAGS -DBOOST_TIMER_ENABLE_DEPRECATED"
 # symbol, not a deprecation flag), so restore it via a force-included compat shim
 # (src/qtum/boost_compat.h) instead of patching the submodule. See that file for
 # details; revisit patching cpp-eth-metrix upstream if this becomes hard to carry.
-CPPFLAGS="$CPPFLAGS -include $(cd "$srcdir" && pwd)/src/qtum/boost_compat.h"
+#
+# This goes into CXXFLAGS rather than CPPFLAGS deliberately: src/Makefile.am's .rc.o
+# rule forwards $(CPPFLAGS) straight to windres for the win64 build's resource file,
+# and windres doesn't understand -include (a GCC-only flag) -- it barfs with a usage
+# dump and a nonzero exit. CXXFLAGS reaches every C++ compile the same way CPPFLAGS
+# does but is never passed to windres, and the shim is already a no-op for C anyway.
+CXXFLAGS="$CXXFLAGS -include $(cd "$srcdir" && pwd)/src/qtum/boost_compat.h"
 
 ERROR_CXXFLAGS=
 if test "x$enable_werror" = "xyes"; then

--- a/depends/packages/gmp.mk
+++ b/depends/packages/gmp.mk
@@ -2,7 +2,7 @@ package=gmp
 $(package)_version=6.1.2
 $(package)_sha256_hash=87b565e89a9a684fe4ebeeddb8399dce2599f9c9049854ca8c0dfbdea0e21912
 $(package)_file_name=$(package)-$($(package)_version).tar.xz
-$(package)_download_path=https://gmplib.org/download/$(package)
+$(package)_download_path=https://ftp.gnu.org/gnu/gmp
 
 define $(package)_set_vars
 $(package)_config_opts=--enable-static=yes --enable-shared=no --enable-cxx


### PR DESCRIPTION
Empty-commit PR opened solely to trigger the new depends-based Test Release Builds workflow on the Testing branch.